### PR TITLE
feat: inbound call audio capture and OVOS microphone integration

### DIFF
--- a/baresipy/__init__.py
+++ b/baresipy/__init__.py
@@ -1,4 +1,5 @@
-from time import sleep
+from time import sleep, time as _time
+import glob
 import pexpect
 from opentone import ToneGenerator
 from pydub import AudioSegment
@@ -9,8 +10,9 @@ from threading import Thread
 from typing import Optional, Tuple, Union
 from baresipy.utils.log import LOG
 from baresipy.tts import get_default_tts
-from baresipy.config import render_config
-from os.path import expanduser, join, isfile, isdir
+from baresipy.config import render_config, ensure_sndfile_recording
+from baresipy.audio import WavTailReader
+from os.path import expanduser, join, isfile, isdir, getmtime
 from os import makedirs
 import signal
 import re
@@ -28,13 +30,23 @@ class BareSIP(Thread):
                  autostart: bool = True,
                  login_options: Optional[str] = None,
                  headless: bool = False,
-                 audio_driver: str = "alsa,default"):
+                 audio_driver: str = "alsa,default",
+                 record_rx: bool = False,
+                 recording_path: Optional[str] = None):
         config_path = config_path or join("~", ".baresipy")
         self.config_path = expanduser(config_path)
         if not isdir(self.config_path):
             makedirs(self.config_path)
 
         self._default_ausrc = "ausine,400" if headless else audio_driver
+
+        self.record_rx = record_rx
+        self.recording_path = None
+        if record_rx:
+            self.recording_path = recording_path or \
+                tempfile.mkdtemp(dir=tempfile.gettempdir())
+            if not isdir(self.recording_path):
+                makedirs(self.recording_path)
 
         if isfile(join(self.config_path, "config")):
             with open(join(self.config_path, "config"), "r") as f:
@@ -47,6 +59,14 @@ class BareSIP(Thread):
             self.updated_config = True
 
         self._original_config = str(self.config)
+
+        if record_rx:
+            # ensure the two sndfile config lines are present regardless of
+            # whether self.config came from render_config or an existing
+            # user-provided config file
+            self.config = ensure_sndfile_recording(self.config,
+                                                     self.recording_path)
+            self.updated_config = True
 
         if sounds_path is not None and "#audio_path" in self.config:
             self.updated_config = True
@@ -186,6 +206,41 @@ class BareSIP(Thread):
         status = "ESTABLISHED"
         self.handle_call_status(status)
         self._call_status = status
+
+    def get_rx_wav(self, timeout: float = 10.0) -> Optional[str]:
+        """Return the path to the newest received-audio wav recording
+        (`*-dec.wav`, ie what the peer said) written by baresip's sndfile
+        module, waiting up to `timeout` seconds for one to appear.
+
+        Requires `record_rx=True` to have been set at construction time.
+        """
+        if not self.recording_path:
+            LOG.error("recording not enabled, pass record_rx=True")
+            return None
+        pattern = join(self.recording_path, "*-dec.wav")
+        deadline = None
+        while True:
+            matches = glob.glob(pattern)
+            if matches:
+                return max(matches, key=getmtime)
+            if deadline is None:
+                deadline = _time() + timeout
+            if _time() >= deadline:
+                return None
+            sleep(0.1)
+
+    def get_rx_stream(self, timeout: float = 10.0) -> Optional[WavTailReader]:
+        """Return a `WavTailReader` tailing the newest received-audio wav
+        recording, or None if no such recording appeared within `timeout`
+        seconds.
+        """
+        wav = self.get_rx_wav(timeout)
+        if not wav:
+            return None
+        try:
+            return WavTailReader(wav, timeout=timeout)
+        except TimeoutError:
+            return None
 
     def list_calls(self) -> None:
         self.do_command("/listcalls")

--- a/baresipy/audio.py
+++ b/baresipy/audio.py
@@ -1,0 +1,151 @@
+"""Helpers for tailing baresip `sndfile` module wav recordings and doing
+lightweight pure-stdlib PCM resampling (no `audioop` - removed in Python
+3.13 - and no numpy dependency).
+"""
+import struct
+import time
+from os.path import isfile
+from typing import Optional
+
+
+class WavTailReader:
+    """Incrementally read a wav file that is still being written to.
+
+    baresip's `sndfile` module writes the RIFF/fmt header first (so
+    channels/rate/bits-per-sample can be read as soon as the header bytes
+    exist), but the RIFF/data chunk SIZE fields are only finalized when the
+    file is closed. This reader parses the fmt chunk once, then keeps
+    reading raw PCM bytes appended after the data-chunk header, ignoring the
+    (stale, likely zero) size field, and tolerates the file not existing
+    yet.
+    """
+
+    def __init__(self, path: str, timeout: float = 5.0):
+        self.path = path
+        self.sample_rate: int = 0
+        self.sample_width: int = 0
+        self.channels: int = 0
+        self._data_offset: int = 0
+        self._pos: int = 0
+        self._closed = False
+        self._wait_for_header(timeout)
+
+    def _wait_for_header(self, timeout: float) -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if isfile(self.path):
+                try:
+                    with open(self.path, "rb") as f:
+                        header = f.read(4096)
+                    if self._parse_header(header):
+                        return
+                except OSError:
+                    pass
+            time.sleep(0.05)
+        raise TimeoutError(
+            f"wav header for {self.path!r} not available after "
+            f"{timeout}s")
+
+    def _parse_header(self, header: bytes) -> bool:
+        if len(header) < 12 or header[0:4] != b"RIFF" or \
+                header[8:12] != b"WAVE":
+            return False
+        offset = 12
+        fmt_found = False
+        while offset + 8 <= len(header):
+            chunk_id = header[offset:offset + 4]
+            chunk_size = struct.unpack_from("<I", header, offset + 4)[0]
+            chunk_body_start = offset + 8
+            if chunk_id == b"fmt ":
+                if chunk_body_start + 16 > len(header):
+                    return False
+                (_audio_format, channels, sample_rate, _byte_rate,
+                 _block_align, bits_per_sample) = struct.unpack_from(
+                    "<HHIIHH", header, chunk_body_start)
+                self.channels = channels
+                self.sample_rate = sample_rate
+                self.sample_width = bits_per_sample // 8
+                fmt_found = True
+            elif chunk_id == b"data":
+                if not fmt_found:
+                    return False
+                self._data_offset = chunk_body_start
+                return True
+            offset = chunk_body_start + chunk_size + (chunk_size % 2)
+        return False
+
+    def read(self, n_bytes: int, timeout: Optional[float] = None) -> bytes:
+        """Block (polling) up to `timeout` seconds for `n_bytes` of new raw
+        PCM data past the data-chunk header. Returns whatever is available
+        (possibly `b""`) if the timeout elapses or the file is gone/closed.
+        """
+        if self._closed:
+            return b""
+        timeout = 5.0 if timeout is None else timeout
+        deadline = time.time() + timeout
+        buf = b""
+        while len(buf) < n_bytes and time.time() < deadline:
+            if not isfile(self.path):
+                break
+            try:
+                with open(self.path, "rb") as f:
+                    f.seek(self._data_offset + self._pos)
+                    chunk = f.read(n_bytes - len(buf))
+            except OSError:
+                break
+            if chunk:
+                buf += chunk
+                self._pos += len(chunk)
+            else:
+                time.sleep(0.01)
+        return buf
+
+    def close(self) -> None:
+        self._closed = True
+
+
+def resample_pcm16(data: bytes, src_rate: int, src_channels: int,
+                    dst_rate: int = 16000) -> bytes:
+    """Downmix multi-channel 16-bit signed PCM (little-endian) to mono by
+    averaging channels, then linearly resample from `src_rate` to
+    `dst_rate`. Pure stdlib, no audioop/numpy.
+    """
+    if not data:
+        return b""
+
+    src_channels = max(1, src_channels)
+    frame_size = 2 * src_channels
+    n_frames = len(data) // frame_size
+    if n_frames == 0:
+        return b""
+
+    samples = struct.unpack_from("<%dh" % (n_frames * src_channels), data)
+
+    if src_channels > 1:
+        mono = [
+            sum(samples[i * src_channels:(i + 1) * src_channels]) //
+            src_channels
+            for i in range(n_frames)
+        ]
+    else:
+        mono = list(samples)
+
+    if src_rate == dst_rate:
+        out = mono
+    else:
+        ratio = src_rate / float(dst_rate)
+        out_len = int(n_frames / ratio)
+        out = []
+        for i in range(out_len):
+            src_pos = i * ratio
+            idx = int(src_pos)
+            frac = src_pos - idx
+            s0 = mono[idx] if idx < n_frames else mono[-1]
+            idx1 = idx + 1
+            s1 = mono[idx1] if idx1 < n_frames else mono[-1]
+            val = s0 + (s1 - s0) * frac
+            out.append(int(val))
+
+    # clamp to int16 range
+    out = [max(-32768, min(32767, v)) for v in out]
+    return struct.pack("<%dh" % len(out), *out)

--- a/baresipy/config.py
+++ b/baresipy/config.py
@@ -1,5 +1,6 @@
 from os.path import isdir
 from typing import Optional
+import re
 
 DEFAULT = """#
 # baresip configuration
@@ -219,9 +220,38 @@ ice_mode		full	# {full,lite}
 #statmode_default	off"""
 
 
+def ensure_sndfile_recording(config: str, snd_path: str) -> str:
+    """Ensure `module sndfile.so` is active and `snd_path` is set in a
+    rendered (or user-provided) baresip config text blob.
+
+    Works whether `config` came from `render_config` or was loaded from an
+    existing config file, by patching the text directly.
+
+    :param config: baresip config file contents
+    :param snd_path: directory where call recordings should be written
+    """
+    if "#module			sndfile.so" in config:
+        config = config.replace(
+            "#module			sndfile.so", "module			sndfile.so")
+    elif "module			sndfile.so" not in config:
+        config = config.replace(
+            "module			vumeter.so",
+            "module			vumeter.so\nmodule			sndfile.so", 1)
+
+    if "snd_path" in config:
+        config = re.sub(r"^snd_path\s+.*$", "snd_path\t\t" + snd_path,
+                         config, flags=re.MULTILINE)
+    else:
+        config += "\nsnd_path\t\t" + snd_path + "\n"
+
+    return config
+
+
 def render_config(audio_driver: str = "alsa,default",
                    headless: bool = False,
-                   audio_path: Optional[str] = None) -> str:
+                   audio_path: Optional[str] = None,
+                   enable_sndfile: bool = False,
+                   snd_path: Optional[str] = None) -> str:
     """Render a baresip config file from the DEFAULT template.
 
     :param audio_driver: value passed to `audio_source`/`audio_player`/
@@ -232,6 +262,10 @@ def render_config(audio_driver: str = "alsa,default",
         present (see github issues #16/#17)
     :param audio_path: if a directory, patch `audio_path` to point at it; if
         False-y but not None, disable sound file loading entirely
+    :param enable_sndfile: if True, activate the `sndfile.so` module so
+        baresip records call audio (rx/tx wav files) into `snd_path`
+    :param snd_path: directory to write call recordings into, required if
+        `enable_sndfile` is True
     """
     config = DEFAULT
 
@@ -270,5 +304,10 @@ def render_config(audio_driver: str = "alsa,default",
             config = config.replace(
                 "#audio_path		/usr/share/baresip",
                 "audio_path		" + audio_path)
+
+    if enable_sndfile:
+        if not snd_path:
+            raise ValueError("snd_path is required when enable_sndfile=True")
+        config = ensure_sndfile_recording(config, snd_path)
 
     return config

--- a/baresipy/ovos.py
+++ b/baresipy/ovos.py
@@ -1,0 +1,87 @@
+"""OVOS integration - a `Microphone` plugin that streams SIP call audio
+captured via baresip's `sndfile` module.
+
+This module lazy-imports `ovos-plugin-manager` so that `import baresipy`
+never requires it to be installed. Install it with `pip install
+baresipy[ovos]`.
+"""
+from dataclasses import dataclass, field
+from typing import Optional, TYPE_CHECKING
+
+from baresipy.audio import WavTailReader, resample_pcm16
+from baresipy.utils.log import LOG
+
+try:
+    from ovos_plugin_manager.templates.microphone import Microphone
+except ImportError as e:
+    raise ImportError(
+        "ovos-plugin-manager is required for baresipy.ovos - "
+        "install it with `pip install baresipy[ovos]`"
+    ) from e
+
+if TYPE_CHECKING:
+    from baresipy import BareSIP
+
+
+@dataclass
+class BareSIPMicrophone(Microphone):
+    """A `Microphone` plugin that reads audio the caller sent during an
+    active SIP call, sourced from baresip's `sndfile`-recorded rx wav file.
+
+    Requires the `BareSIP` instance to have been constructed with
+    `record_rx=True`.
+    """
+    sip: Optional["BareSIP"] = None
+    sample_rate: int = 16000
+    sample_width: int = 2
+    sample_channels: int = 1
+    chunk_size: int = 4096
+
+    _stream: Optional[WavTailReader] = field(default=None, repr=False)
+
+    def start(self):
+        if self.sip is None:
+            raise ValueError("BareSIPMicrophone requires sip=<BareSIP instance>")
+        while not self.sip.call_established:
+            if self.sip.abort or not self.sip.running:
+                return
+            from time import sleep
+            sleep(0.1)
+        self._stream = self.sip.get_rx_stream()
+        if self._stream is None:
+            LOG.error("no rx recording available, is record_rx=True set?")
+
+    def read_chunk(self) -> Optional[bytes]:
+        if self._stream is None or self.sip is None or \
+                not self.sip.call_established:
+            return None
+
+        dst_frame_bytes = self.sample_width * self.sample_channels
+        needed_frames = self.chunk_size // dst_frame_bytes
+
+        out = b""
+        while len(out) < needed_frames * dst_frame_bytes:
+            src_frame_size = self._stream.sample_width * \
+                max(1, self._stream.channels)
+            # read a generous amount of source bytes to produce enough
+            # resampled output, accounting for the resample ratio
+            ratio = self._stream.sample_rate / float(self.sample_rate) \
+                if self.sample_rate else 1.0
+            src_bytes_needed = int(
+                (needed_frames - len(out) // dst_frame_bytes) *
+                ratio) * src_frame_size
+            src_bytes_needed = max(src_bytes_needed, src_frame_size)
+            raw = self._stream.read(src_bytes_needed, timeout=1.0)
+            if not raw:
+                return None if not out else out
+            resampled = resample_pcm16(
+                raw, self._stream.sample_rate, self._stream.channels,
+                dst_rate=self.sample_rate)
+            out += resampled
+
+        return out[:needed_frames * dst_frame_bytes]
+
+    def stop(self):
+        if self._stream is not None:
+            self._stream.close()
+            self._stream = None

--- a/examples/voice_bot.py
+++ b/examples/voice_bot.py
@@ -1,0 +1,72 @@
+"""Registrar-capable inbound voice-assistant example.
+
+Answers incoming SIP calls, listens to the caller via an OVOS
+`ovos-simple-listener`, transcribes speech and echoes it back with TTS.
+
+Required installs:
+    pip install baresipy[ovos] ovos-stt-plugin-server ovos-vad-plugin-webrtcvad
+
+Plugin selection (which STT/VAD/TTS engine actually runs) is read by the
+OVOS Plugin Manager factories (`OVOSSTTFactory`, `OVOSVADFactory`, and
+`baresipy`'s own TTS lookup) from `mycroft.conf`, so this example stays
+generic - swap plugins by editing your `mycroft.conf`, not this script.
+"""
+from time import sleep
+
+from ovos_plugin_manager.stt import OVOSSTTFactory
+from ovos_plugin_manager.vad import OVOSVADFactory
+from ovos_simple_listener import ListenerCallbacks, SimpleListener
+
+from baresipy import BareSIP
+from baresipy.ovos import BareSIPMicrophone
+from baresipy.utils.log import LOG
+
+gateway = "your_sip.gateway.net"
+user = "your_phone"
+pswd = "your_password"
+
+
+class VoiceBotCallbacks(ListenerCallbacks):
+    sip: "VoiceBot" = None
+
+    @classmethod
+    def text_callback(cls, utterance: str, lang: str):
+        LOG.info(f"STT: {utterance}")
+        if cls.sip is not None:
+            cls.sip.speak(f"you said: {utterance}")
+
+
+class VoiceBot(BareSIP):
+    def __init__(self, *args, **kwargs):
+        kwargs["record_rx"] = True
+        super().__init__(*args, **kwargs)
+        self.listener = None
+        VoiceBotCallbacks.sip = self
+
+    def handle_incoming_call(self, number: str) -> None:
+        LOG.info("Incoming call: " + number)
+        self.accept_call()
+
+    def handle_call_established(self) -> None:
+        LOG.info("Call established, starting listener")
+        mic = BareSIPMicrophone(sip=self)
+        self.listener = SimpleListener(
+            mic=mic,
+            wakeword=None,
+            vad=OVOSVADFactory.create(),
+            stt=OVOSSTTFactory.create(),
+            callbacks=VoiceBotCallbacks(),
+        )
+        self.listener.start()
+
+    def handle_call_ended(self, reason: str, number=None) -> None:
+        LOG.info("Call ended")
+        if self.listener is not None:
+            self.listener.stop()
+            self.listener = None
+
+
+if __name__ == "__main__":
+    bot = VoiceBot(user, pswd, gateway, debug=False)
+    while bot.running:
+        sleep(0.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ test = [
 ]
 ovos = [
     "ovos-plugin-manager",
-    "ovos-tts-plugin-phoonnx",
+    "phoonnx",
+    "ovos-simple-listener",
 ]
 
 [project.urls]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -49,5 +49,23 @@ class TestRenderConfig(unittest.TestCase):
         self.assertIn("#audio_path\t\t/usr/share/baresip", config)
 
 
+class TestRenderConfigSndfile(unittest.TestCase):
+    def test_sndfile_disabled_by_default(self):
+        config = render_config()
+        self.assertIn("#module\t\t\tsndfile.so", config)
+        self.assertNotIn("\nmodule\t\t\tsndfile.so\n", config)
+        self.assertNotIn("snd_path", config)
+
+    def test_sndfile_enabled(self):
+        config = render_config(enable_sndfile=True, snd_path="/tmp/rec")
+        self.assertIn("module\t\t\tsndfile.so", config)
+        self.assertNotIn("#module\t\t\tsndfile.so", config)
+        self.assertIn("snd_path\t\t/tmp/rec", config)
+
+    def test_sndfile_enabled_requires_snd_path(self):
+        with self.assertRaises(ValueError):
+            render_config(enable_sndfile=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_ovos_optional.py
+++ b/test/test_ovos_optional.py
@@ -1,0 +1,23 @@
+import unittest
+
+
+class TestOvosOptionalDependency(unittest.TestCase):
+    def test_baresipy_import_does_not_require_ovos(self):
+        import baresipy  # noqa: F401
+        self.assertTrue(hasattr(baresipy, "BareSIP"))
+
+    def test_baresipy_ovos_import_error_mentions_extra(self):
+        try:
+            import ovos_plugin_manager  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.skipTest("ovos-plugin-manager is installed in this env")
+
+        with self.assertRaises(ImportError) as ctx:
+            import baresipy.ovos  # noqa: F401
+        self.assertIn("baresipy[ovos]", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_resample.py
+++ b/test/test_resample.py
@@ -1,0 +1,69 @@
+import math
+import struct
+import unittest
+
+from baresipy.audio import resample_pcm16
+
+
+def make_sine(n_frames, channels, rate, freq=440.0, amplitude=10000):
+    samples = []
+    for i in range(n_frames):
+        val = int(amplitude * math.sin(2 * math.pi * freq * i / rate))
+        for _ in range(channels):
+            samples.append(val)
+    return struct.pack("<%dh" % len(samples), *samples)
+
+
+def count_zero_crossings(data):
+    (n,) = (len(data) // 2,)
+    samples = struct.unpack("<%dh" % n, data)
+    crossings = 0
+    for i in range(1, len(samples)):
+        if (samples[i - 1] < 0) != (samples[i] < 0):
+            crossings += 1
+    return crossings
+
+
+class TestResamplePcm16(unittest.TestCase):
+    def test_length_approx_ratio(self):
+        src_rate, dst_rate, channels = 48000, 16000, 2
+        n_frames = 4800
+        data = make_sine(n_frames, channels, src_rate)
+        out = resample_pcm16(data, src_rate, channels, dst_rate=dst_rate)
+        out_frames = len(out) // 2
+        expected = n_frames // 3  # only sample-rate ratio downsamples frames
+        self.assertLessEqual(abs(out_frames - expected), 1)
+
+    def test_constant_signal_stays_constant(self):
+        src_rate, dst_rate, channels = 48000, 16000, 2
+        n_frames = 1000
+        value = 1234
+        samples = [value] * (n_frames * channels)
+        data = struct.pack("<%dh" % len(samples), *samples)
+        out = resample_pcm16(data, src_rate, channels, dst_rate=dst_rate)
+        out_samples = struct.unpack("<%dh" % (len(out) // 2), out)
+        for s in out_samples:
+            self.assertEqual(s, value)
+
+    def test_sine_frequency_roughly_preserved(self):
+        src_rate, dst_rate, channels = 48000, 16000, 1
+        freq = 440.0
+        duration_s = 0.5
+        n_frames = int(src_rate * duration_s)
+        data = make_sine(n_frames, channels, src_rate, freq=freq)
+        out = resample_pcm16(data, src_rate, channels, dst_rate=dst_rate)
+
+        # zero-crossing count is a function of frequency * duration, and is
+        # independent of sample rate as long as both rates are well above
+        # Nyquist for `freq` - so it should be roughly preserved across
+        # resampling (same represented duration, same tone).
+        src_crossings = count_zero_crossings(data)
+        dst_crossings = count_zero_crossings(out)
+
+        self.assertAlmostEqual(
+            dst_crossings, src_crossings,
+            delta=max(2, src_crossings * 0.10))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_wav_tail.py
+++ b/test/test_wav_tail.py
@@ -1,0 +1,73 @@
+import os
+import tempfile
+import threading
+import time
+import unittest
+import wave
+
+from baresipy.audio import WavTailReader
+
+
+class TestWavTailReader(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.path = os.path.join(self.tmpdir, "dump-test-dec.wav")
+
+    def test_reads_header_and_growing_data(self):
+        rate = 8000
+        channels = 1
+        width = 2
+        frame1 = b"\x01\x00" * 100
+        frame2 = b"\x02\x00" * 100
+
+        def writer():
+            wf = wave.open(self.path, "wb")
+            wf.setnchannels(channels)
+            wf.setsampwidth(width)
+            wf.setframerate(rate)
+            wf.writeframes(frame1)
+            wf._file.flush()
+            time.sleep(0.3)
+            wf.writeframes(frame2)
+            wf._file.flush()
+            time.sleep(0.5)
+            wf.close()
+
+        t = threading.Thread(target=writer)
+        t.start()
+
+        try:
+            reader = WavTailReader(self.path, timeout=5.0)
+            self.assertEqual(reader.sample_rate, rate)
+            self.assertEqual(reader.channels, channels)
+            self.assertEqual(reader.sample_width, width)
+
+            data = reader.read(len(frame1), timeout=5.0)
+            self.assertEqual(data, frame1)
+
+            data2 = reader.read(len(frame2), timeout=5.0)
+            self.assertEqual(data2, frame2)
+
+            reader.close()
+        finally:
+            t.join()
+
+    def test_read_timeout_returns_empty_when_no_data(self):
+        wf = wave.open(self.path, "wb")
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(8000)
+        wf.writeframes(b"\x00\x00" * 10)
+        wf.close()
+
+        reader = WavTailReader(self.path, timeout=5.0)
+        # ask for way more data than exists, with a short timeout
+        start = time.time()
+        data = reader.read(100000, timeout=0.3)
+        elapsed = time.time() - start
+        self.assertLess(len(data), 100000)
+        self.assertLess(elapsed, 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Exposes received call audio as a byte stream and integrates baresipy with the OVOS voice stack.

## Changes
- **Inbound audio capture**: `BareSIP(record_rx=True, recording_path=...)` enables baresip's `sndfile` module (config key `snd_path`), which records the decoded RX leg per call. `get_rx_wav()` returns the newest recording; `get_rx_stream()` returns a `WavTailReader`.
- **`baresipy/audio.py`**: `WavTailReader` incrementally reads a wav that baresip is still writing (parses the fmt chunk for rate/width/channels, streams raw PCM past the data header, ignores the stale size field). `resample_pcm16()` is a pure-stdlib downmix + linear resampler (no `audioop`, which is removed in Python 3.13; no numpy).
- **`baresipy/ovos.py`**: `BareSIPMicrophone`, an `ovos_plugin_manager.templates.microphone.Microphone` implementation that yields the caller's speech as 16 kHz/16-bit/mono chunks — drop it into `ovos-simple-listener`'s `SimpleListener(mic=...)` for wakeword/VAD/STT over a phone call. Lazy imports: base `import baresipy` never needs OPM; importing `baresipy.ovos` without it raises a clear error pointing at the extra.
- **`examples/voice_bot.py`**: a complete SIP voice assistant — auto-answers, listens with `SimpleListener` (VAD-only activation + OPM STT via `mycroft.conf`), replies through TTS into the call.
- **`[ovos]` extra**: `ovos-plugin-manager`, `ovos-simple-listener`, `phoonnx` (ships the `ovos-tts-plugin-phoonnx` TTS plugin used as the default engine).

## Plugin usage
The example reads standard OVOS config: STT/VAD plugins from `~/.config/mycroft/mycroft.conf` via `OVOSSTTFactory`/`OVOSVADFactory`; TTS defaults to `{"module": "ovos-tts-plugin-phoonnx"}` (any OPM TTS instance can be passed as `tts=`).

## Verification
- Full suite (58 tests) green in a fresh uv venv without the ovos extra; `ruff` clean; `uv build` ok.
- With `ovos-plugin-manager` + `ovos-simple-listener` installed, `from baresipy.ovos import BareSIPMicrophone` imports cleanly.
- Live call e2e (two containers, real RTP audio) lands with the docker test rig in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
