### PR TITLE
docs: full setup documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+Guidance for agents working in this repository.
+
+## Module layout
+
+- `baresipy/__init__.py` — `BareSIP`, the core `Thread` subclass wrapping a `baresip` process
+  via `pexpect`: registration/registrar-less login, call control, DTMF, TTS/audio playback into
+  a call, rx recording, and the baresip output-line state machine (`_handle_output_line`).
+- `baresipy/config.py` — the default baresip config template (`DEFAULT`) and
+  `render_config()`/`ensure_sndfile_recording()`, which render/patch a config text blob
+  (headless mode, sound driver, sndfile recording).
+- `baresipy/audio.py` — `WavTailReader` (tails a growing baresip `sndfile` wav recording) and
+  `resample_pcm16()` (pure-stdlib PCM downmix/resample, no `audioop`/numpy).
+- `baresipy/ovos.py` — `BareSIPMicrophone`, an OVOS Plugin Manager `Microphone` implementation
+  reading call rx audio. Lazy-imports `ovos-plugin-manager`; importing this module without the
+  `[ovos]` extra installed raises `ImportError`.
+- `baresipy/tts.py` — `get_default_tts()`, lazily creates a default OPM TTS plugin
+  (`ovos-tts-plugin-phoonnx`) for `BareSIP.speak()`/`say()` when no `tts=` was passed.
+- `baresipy/contacts.py` — `ContactList`, an optional local JSON-backed contact store, separate
+  from `BareSIP`.
+- `baresipy/utils/log.py` — shared `LOG` logger instance.
+
+Full narrative docs live under `docs/` — see [README.md](README.md) for the index. Don't
+duplicate that content here; keep this file focused on orientation for agents.
+
+## Tests
+
+Use [uv](https://github.com/astral-sh/uv):
+
+```bash
+uv venv .venv
+VIRTUAL_ENV=$PWD/.venv uv pip install -e .[test]
+VIRTUAL_ENV=$PWD/.venv .venv/bin/pytest test/
+```
+
+- Tests live in a single flat `test/` directory (not `tests/`).
+- `pyproject.toml` sets `addopts = "-m 'not e2e'"` — the `e2e` marker (registered there) is
+  excluded by default since it requires docker.
+- Most tests should use the fake-`pexpect` pattern in `test/test_state_machine.py`
+  (`patch.object(baresipy.pexpect, "spawn")`, `autostart=False`, a throwaway `config_path`) so
+  they never spawn a real `baresip` process or touch `~/.baresipy`.
+- Never skip a test because an optional dependency is missing; `baresipy` core has no optional
+  deps, and `[ovos]`-only behavior is covered by `test/test_ovos_optional.py`, which asserts the
+  `ImportError` message rather than being skipped.
+
+## E2E rig
+
+`docker-compose.e2e.yml` + `test/e2e/` spin up two real, registrar-less, headless `baresip`
+processes in separate containers that call each other directly by static IP, exchange DTMF and
+audio, and assert on the result. Run with `pytest test/ -m e2e` or
+`docker compose -f docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from caller`.
+See [docs/docker.md](docs/docker.md) for full details. Requires docker; treat it as the
+ground-truth reference for registrar-less/direct-call behavior when in doubt about how baresip's
+IP-matching for incoming calls works.
+
+## Linting
+
+```bash
+uvx ruff check .
+```
+
+`examples/` is linted along with the rest of the tree — keep example scripts syntactically valid
+and import-clean even though they contain placeholder credentials.
+
+## Project rules
+
+- Never hand-edit `baresipy/version.py`.
+- Docs (README.md, docs/, AGENTS.md) describe current behavior only — no changelog-style
+  commentary, no "recently added"/"previously" framing, no version comparisons.

--- a/README.md
+++ b/README.md
@@ -1,55 +1,62 @@
-# Baresipy
-
-A python wrapper around [baresip](https://github.com/alfredh/baresip)
-
-Make voip calls/bots from python!
+# baresipy
 
 ![](./logo.png)
 
-# install
+A python wrapper around [baresip](https://github.com/baresip/baresip), the portable SIP user-agent.
+
+Use it to place and receive VoIP calls from python: dial out, answer inbound calls, stream
+text-to-speech or arbitrary audio into a call, send/receive DTMF, transcribe what a caller says,
+and build interactive voice bots — with or without a SIP registrar, with or without a sound card.
+
+## Install
 
 ```bash
-sudo apt-get install baresip
-sudo apt-get install ffmpeg
+sudo apt-get install baresip ffmpeg   # Debian/Ubuntu, see docs/setup.md for other distros
 pip install baresipy
 ```
 
-# usage
+`baresip` is the SIP engine baresipy drives via `pexpect`; `ffmpeg` is used by `pydub` for audio
+conversion. See [docs/setup.md](docs/setup.md) for per-distro install commands, SIP account
+requirements, and troubleshooting.
 
-scripted calls
+Optional extras:
+
+| extra | installs | needed for |
+|---|---|---|
+| `baresipy[ovos]` | `ovos-plugin-manager`, `phoonnx`, `ovos-simple-listener` | `speak()`/`say()` default TTS engine, `baresipy.ovos.BareSIPMicrophone`, voice bots |
+| `baresipy[test]` | `pytest`, `pytest-cov` | running the test suite |
+
+## Quickstart
+
+### Scripted call
+
+Dial a number, speak, hang up:
 
 ```python
 from baresipy import BareSIP
 from time import sleep
 
-to = "jarbas_laptop@sipx.mattkeys.net"
-
-gateway = "sipx.xxxxx.net"
-user = "xxxxx"
-pswd = "xxxxxx"
-
-b = BareSIP(user, pswd, gateway)
-
-b.call(to)
+b = BareSIP("your_user", "your_password", "your_sip_gateway.example")
+b.call("someone@your_sip_gateway.example")
 
 while b.running:
     sleep(0.5)
     if b.call_established:
-        b.send_dtmf("123")
-        b.speak("this is jarbas personal assistant speaking. this was a test")
-        b.speak("Goodbye")
+        b.speak("hello, this is a test")
         b.hang()
         b.quit()
-
+        break
 ```
 
+Full runnable version: [examples/scripted_call.py](examples/scripted_call.py).
 
-handling events
+### Answering bot
+
+Subclass `BareSIP` and override the event handlers:
 
 ```python
 from baresipy import BareSIP
 from time import sleep
-from pyjokes import get_joke
 
 
 class JokeBOT(BareSIP):
@@ -58,23 +65,76 @@ class JokeBOT(BareSIP):
 
     def handle_call_established(self):
         self.speak("Welcome to the jokes bot")
-        self.speak(get_joke())
         self.speak("Goodbye")
         self.hang()
 
 
-gateway = "sipx.xxxxx.net"
-user = "xxxxxx"
-pswd = "xxxx"
-
-b = JokeBOT(user, pswd, gateway)
-
+b = JokeBOT("your_user", "your_password", "your_sip_gateway.example")
 while b.running:
     sleep(1)
-
 ```
 
-        
-# Credits
+Full runnable version: [examples/events.py](examples/events.py).
 
-This work as been sponsored by Matt Keys, [eZuce Inc](https://ezuce.com/)
+### OVOS voice bot
+
+Answer a call and transcribe the caller with an [OVOS](https://openvoiceos.org) STT/VAD pipeline,
+using the incoming call audio as a microphone source:
+
+```python
+from baresipy import BareSIP
+from baresipy.ovos import BareSIPMicrophone
+from ovos_plugin_manager.stt import OVOSSTTFactory
+from ovos_plugin_manager.vad import OVOSVADFactory
+from ovos_simple_listener import SimpleListener, ListenerCallbacks
+
+
+class VoiceBot(BareSIP):
+    def handle_incoming_call(self, number):
+        self.accept_call()
+
+    def handle_call_established(self):
+        mic = BareSIPMicrophone(sip=self)
+        SimpleListener(mic=mic, wakeword=None,
+                        vad=OVOSVADFactory.create(),
+                        stt=OVOSSTTFactory.create(),
+                        callbacks=ListenerCallbacks()).start()
+
+
+bot = VoiceBot("your_user", "your_password", "your_sip_gateway.example", record_rx=True)
+```
+
+Full runnable version with two-way TTS replies: [examples/voice_bot.py](examples/voice_bot.py).
+See [docs/ovos-integration.md](docs/ovos-integration.md) for the complete walkthrough.
+
+## Features
+
+| Feature | How |
+|---|---|
+| Registered SIP account calls | `BareSIP(user, pwd, gateway)` |
+| Registrar-less direct SIP calls | `BareSIP()` + `call("sip:user@ip:5060")`, see [docs/direct-calls.md](docs/direct-calls.md) |
+| Headless operation (no sound card) | `BareSIP(headless=True)` |
+| Text-to-speech into a call | `speak()` via any [OPM](https://github.com/OpenVoiceOS/ovos-plugin-manager) TTS plugin |
+| Arbitrary audio into a call | `send_audio(path)` |
+| DTMF (send/receive) | `send_dtmf(digits, mode="keys")`, `handle_dtmf_received()` |
+| Recording inbound call audio | `record_rx=True`, `get_rx_wav()` / `get_rx_stream()` |
+| OVOS microphone plugin | `baresipy.ovos.BareSIPMicrophone` |
+| Local contact list | `baresipy.contacts.ContactList` |
+| Event-driven call handling | override `handle_*` methods |
+
+## Documentation
+
+- [docs/setup.md](docs/setup.md) — system dependencies, install, verifying with a first call, troubleshooting
+- [docs/configuration.md](docs/configuration.md) — config directory, `render_config`, full `BareSIP` constructor reference
+- [docs/direct-calls.md](docs/direct-calls.md) — registrar-less/direct SIP mode
+- [docs/ovos-integration.md](docs/ovos-integration.md) — building a full OVOS voice bot
+- [docs/docker.md](docs/docker.md) — container image usage and the e2e rig
+- [docs/testing.md](docs/testing.md) — running and writing tests
+
+## Credits
+
+This work has been sponsored by Matt Keys, [eZuce Inc](https://ezuce.com/)
+
+## License
+
+[MIT](LICENSE.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,77 @@
+# Configuration
+
+How baresipy manages its baresip config file, and the full `BareSIP` constructor reference.
+
+## Config directory
+
+By default baresipy keeps its baresip config under `~/.baresipy` (override with `config_path=`).
+On first run, if `~/.baresipy/config` doesn't exist yet, baresipy renders one from its built-in
+template (`baresipy.config.DEFAULT`) via `render_config()` and writes it there. If a config file
+already exists at that path, it's loaded and used as-is (only `record_rx`/`sounds_path`, if
+passed, patch it further — see below).
+
+Whenever baresipy generates or patches the config, it first backs up whatever was there as
+`~/.baresipy/config.bak`, then restores that original content when the instance `quit()`s
+cleanly — so a `BareSIP()` run never permanently overwrites a hand-edited config.
+
+## `render_config()`
+
+```python
+from baresipy.config import render_config
+
+config_text = render_config(audio_driver="alsa,default", headless=False,
+                             audio_path=None, enable_sndfile=False, snd_path=None)
+```
+
+- **`audio_driver`** — value used for `audio_source`/`audio_player`/`audio_alert` when not
+  headless, eg. `"alsa,default"` or `"pulse,default"`.
+- **`headless`** — if `True`, don't load `alsa.so`/`pulse.so` at all. Instead use `ausine.so`
+  (synthesized sine wave) as the audio source and `aufile.so` (writing to `/dev/null`) as the
+  player/alert, so baresip runs without any sound hardware present.
+- **`audio_path`** — if a directory, patches `audio_path` to point at it (where baresip looks for
+  sound prompts). If falsy but not `None`, disables sound file loading entirely
+  (`audio_path /dont/load`).
+- **`enable_sndfile`** — if `True`, activates the `sndfile.so` module so baresip records call
+  audio (both legs) to `snd_path`. Requires `snd_path`.
+- **`snd_path`** — directory to write call recordings into.
+
+`ensure_sndfile_recording(config, snd_path)` is the lower-level helper used to patch an
+*existing* config (freshly rendered or loaded from disk) to turn on `sndfile.so` recording —
+this is what the `BareSIP(record_rx=True)` kwarg uses under the hood, and works whether or not
+`sndfile.so` / `snd_path` lines are already present.
+
+## `BareSIP` constructor reference
+
+```python
+BareSIP(
+    user=None, pwd=None, gateway=None, transport="udp",
+    tts=None, debug=False, block=True, config_path=None,
+    sounds_path=None, autostart=True, login_options=None,
+    headless=False, audio_driver="alsa,default",
+    record_rx=False, recording_path=None,
+)
+```
+
+| kwarg | default | meaning |
+|---|---|---|
+| `user` | `None` | SIP username. Optional in registrar-less mode (see [docs/direct-calls.md](direct-calls.md)); used as the local account name if omitted (`"baresipy"`). |
+| `pwd` | `None` | SIP account password, used to build `auth_pass=` in the registration URI. Only meaningful when `gateway` is set. |
+| `gateway` | `None` | SIP registrar/proxy host. If set, baresipy registers `sip:user@gateway;transport=...;auth_pass=...` and bare `call(number)` resolves against it. If unset, baresipy runs registrar-less (see below). |
+| `transport` | `"udp"` | `"udp"` or `"tcp"`, appended to the registration URI as `;transport=...`. |
+| `tts` | `None` | An OVOS Plugin Manager TTS instance (anything exposing `get_tts(text, wav_file) -> (wav_file, phonemes)`) used by `speak()`/`say()`. If `None`, a default `ovos-tts-plugin-phoonnx` engine is created lazily on first use (requires the `[ovos]` extra). |
+| `debug` | `False` | Log every raw line read from the baresip process. |
+| `block` | `True` | If `True`, `start()` blocks until `self.ready` becomes `True` (registration/local-UA setup complete) before returning. |
+| `config_path` | `None` | Directory holding the baresip `config` file. Defaults to `~/.baresipy`. Created if missing. |
+| `sounds_path` | `None` | If a directory, patches `audio_path` in the config to point at it (baresip prompt sounds). If `False`, disables sound file loading. If `None` (default), leaves the config's `audio_path` untouched. |
+| `autostart` | `True` | If `True`, calls `start()` (which spawns the event-loop thread, and blocks if `block=True`) at the end of `__init__`. Set `False` to construct without starting, eg. in tests. |
+| `login_options` | `None` | Extra SIP URI parameters appended to the registration line (`;login_options`), for provider-specific requirements. Only applies when `gateway` is set. |
+| `headless` | `False` | If `True`, render the config with `ausine`/`aufile` instead of a real sound driver — no sound card required. See [docs/setup.md](setup.md#troubleshooting). |
+| `audio_driver` | `"alsa,default"` | Value used for the real audio source/player/alert when `headless=False`, eg. `"pulse,default"`. |
+| `record_rx` | `False` | Enables baresip's `sndfile` module so the audio the caller sends (rx leg) is written to disk as it happens. Required for `get_rx_wav()`/`get_rx_stream()` and for `baresipy.ovos.BareSIPMicrophone`. |
+| `recording_path` | `None` | Directory `sndfile` recordings are written to when `record_rx=True`. Defaults to a fresh temp directory. |
+
+### Other constructor kwargs used indirectly
+
+`ContactList(database_name="contacts.db", db_dir=None)` (in `baresipy.contacts`) is a separate,
+optional local JSON contact store — not wired into `BareSIP` automatically. `db_dir` defaults to
+`~/.baresip`. See its docstrings / `examples/contact_list.py`.

--- a/docs/direct-calls.md
+++ b/docs/direct-calls.md
@@ -1,0 +1,75 @@
+# Direct calls (registrar-less mode)
+
+Placing and receiving SIP calls between two baresipy instances without any SIP registrar, proxy,
+or account credentials.
+
+## How it works
+
+If `BareSIP()` is constructed with `user`/`pwd`/`gateway` all left unset, there's nothing to
+register with. baresipy instead creates a local, non-registering user agent as soon as baresip
+signals it's ready:
+
+```
+/uanew sip:<user or "baresipy">@0.0.0.0;regint=0
+```
+
+`regint=0` tells baresip not to attempt SIP REGISTER at all — the UA exists purely so baresip can
+place and accept calls locally. `user` is still accepted in this mode (it becomes the local
+account's SIP username) even though `pwd`/`gateway` are not required.
+
+Because there's no registrar to resolve short numbers against, `call()` in registrar-less mode
+requires a full SIP URI:
+
+```python
+b = BareSIP(user="alice")          # no gateway -> registrar-less
+b.call("sip:bob@192.168.1.42:5060")
+```
+
+Calling `call()` with a bare number and no `gateway` configured raises `ValueError` — there's
+nowhere to resolve it against.
+
+## Receiving direct calls
+
+**Important caveat**: baresip only accepts an incoming call when the request-URI matches its
+local account:
+
+- the request-URI **host** must be one of the machine's own local IP addresses (not a hostname,
+  and not `0.0.0.0`), and
+- the request-URI **user** part must match the local account's user.
+
+In practice this means the caller must dial the callee using the callee's actual reachable IP
+and the exact user the callee registered locally, eg.:
+
+```python
+# callee, on host 192.168.1.42
+callee = BareSIP(user="bob", headless=True)
+
+# caller, elsewhere
+caller = BareSIP(user="alice", headless=True)
+caller.call("sip:bob@192.168.1.42:5060")
+```
+
+Dialing `bob@some-hostname` or `bob@0.0.0.0` from the caller side will not be accepted by the
+callee, even on the same machine/network — resolve the callee's IP first and dial that.
+
+By default, `BareSIP.handle_incoming_call()` rejects every inbound call. To answer, subclass and
+override it, calling `accept_call()`:
+
+```python
+class Callee(BareSIP):
+    def handle_incoming_call(self, number):
+        self.accept_call()
+```
+
+## Working reference: the docker e2e rig
+
+`docker-compose.e2e.yml` and `test/e2e/` are a complete, working example of two registrar-less,
+headless baresip instances calling each other directly by IP over a private docker network — a
+`callee` service that auto-accepts and echoes DTMF, and a `caller` service that dials it, sends
+DTMF and a test tone, and asserts on the exchange. Both services are assigned static IPs in the
+compose network specifically because of the IP-matching requirement described above (the caller
+dials `sip:callee@172.31.99.10:5060`, the callee's static address, not a hostname).
+
+See [docs/docker.md](docker.md) for how to run it, and `test/e2e/callee.py` / `test/e2e/caller.py`
+for the full implementation (event handling, DTMF, recording the rx audio leg, and writing
+results for `test/e2e/test_call.py` to assert on).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,84 @@
+# Docker
+
+Running baresipy in a container, and the two-container end-to-end call rig.
+
+## Image
+
+`Dockerfile` builds a `python:3.12-slim` image with the system `baresip` and `ffmpeg` packages
+installed, plus `baresipy` itself (`pip install .`).
+
+Pull the published image:
+
+```bash
+docker pull ghcr.io/tigregotico/baresipy:latest
+```
+
+Available tags: `:dev` (tracks the development branch), `:latest` (latest release), and semver
+tags (eg. `:1.2.3`) for pinned versions.
+
+Build locally:
+
+```bash
+docker build -t baresipy .
+```
+
+### Installing the `[ovos]` extra in the image
+
+By default the image installs no extras. Pass `INSTALL_EXTRAS` at build time to pull in
+`ovos-plugin-manager`, `phoonnx`, and `ovos-simple-listener`:
+
+```bash
+docker build --build-arg INSTALL_EXTRAS="[ovos]" -t baresipy-ovos .
+```
+
+## Running a bot in a container
+
+The image's default `CMD` is `python`. Mount or `COPY` your bot script and run it directly, eg.:
+
+```bash
+docker run --rm -it \
+    -p 5060:5060/udp \
+    -v $(pwd)/my_bot.py:/app/my_bot.py \
+    baresipy python my_bot.py
+```
+
+Containers rarely have a real sound card, so bots run in them should use `headless=True` (see
+[docs/setup.md](setup.md#troubleshooting)).
+
+### Port considerations
+
+- **`5060/udp`** (or `/tcp`, matching your `transport`) — SIP signalling. Must be published/
+  reachable for the container to register with a gateway or receive direct calls.
+- **RTP range** — the actual call audio. baresip's default config doesn't pin a fixed RTP range
+  (see the commented `#rtp_ports 10000-20000` line in the config template,
+  [docs/configuration.md](configuration.md)); for containers behind NAT/port-mapping you will
+  generally want to set and publish an explicit range so audio can traverse it.
+
+## The e2e rig
+
+`docker-compose.e2e.yml` runs two registrar-less, headless baresip instances (`callee` and
+`caller`) that call each other directly by static IP over a private compose network — no SIP
+registrar involved, exercising the direct-call path described in
+[docs/direct-calls.md](direct-calls.md). `callee` auto-accepts and echoes back DTMF `"42"`;
+`caller` dials, sends DTMF `"7"` plus a generated sine-wave wav, waits for the echo, and writes
+`results.json` to a shared volume for `test/e2e/test_call.py` to assert on (call established,
+DTMF received both ways, non-silent rx audio recorded).
+
+Both services get static IPs (`172.31.99.10`/`172.31.99.11`) specifically because baresip only
+accepts an incoming call whose request-URI host is one of its own local addresses — the caller
+dials the callee's IP, not a docker DNS hostname.
+
+Run it directly:
+
+```bash
+docker compose -f docker-compose.e2e.yml up --build \
+    --abort-on-container-exit --exit-code-from caller
+```
+
+or via pytest, which drives the same compose command against a temp shared directory:
+
+```bash
+pytest test/ -m e2e
+```
+
+See [docs/testing.md](testing.md) for how the e2e marker fits into the rest of the test suite.

--- a/docs/ovos-integration.md
+++ b/docs/ovos-integration.md
@@ -1,0 +1,133 @@
+# OVOS integration
+
+Building a voice bot that answers a call, transcribes what the caller says with an
+[OVOS](https://openvoiceos.org) STT/VAD pipeline, and replies with TTS.
+
+## Install
+
+```bash
+pip install baresipy[ovos]
+```
+
+This pulls in `ovos-plugin-manager`, `phoonnx` (the default TTS engine), and
+`ovos-simple-listener`. `baresipy` itself never requires these — plain `import baresipy` always
+works — but `baresipy.ovos` and the default TTS lookup do.
+
+You'll also need STT and VAD plugins, chosen for your use case. Examples:
+
+```bash
+pip install ovos-stt-plugin-fasterwhisper   # local Whisper-based STT
+# or
+pip install ovos-stt-plugin-server          # STT via a remote ovos-stt-server
+
+pip install ovos-vad-plugin-silero          # or ovos-vad-plugin-webrtcvad
+```
+
+## Configuring plugins
+
+Which STT/VAD/TTS engine actually runs is read from the standard OVOS config,
+`~/.config/mycroft/mycroft.conf`, by the OVOS Plugin Manager factories
+(`OVOSSTTFactory`, `OVOSVADFactory`) and by baresipy's own default TTS lookup
+(`ovos_plugin_manager.tts.OVOSTTSFactory`). Example snippet:
+
+```json
+{
+  "stt": {
+    "module": "ovos-stt-plugin-fasterwhisper",
+    "ovos-stt-plugin-fasterwhisper": {"model": "base"}
+  },
+  "listener": {
+    "VAD": {"module": "ovos-vad-plugin-silero"}
+  },
+  "tts": {
+    "module": "ovos-tts-plugin-phoonnx"
+  }
+}
+```
+
+Swap plugins by editing this file, not your bot's python code — the factories pick up whatever
+is configured at runtime.
+
+## `BareSIPMicrophone`
+
+`baresipy.ovos.BareSIPMicrophone` (an OPM `Microphone` plugin) tails the audio a caller sent
+during an active call and feeds it to any OVOS listener component. It requires the `BareSIP`
+instance it wraps to have been constructed with `record_rx=True`, so baresip's `sndfile` module
+is recording the rx leg to disk as the call happens:
+
+```python
+from baresipy import BareSIP
+from baresipy.ovos import BareSIPMicrophone
+
+sip = BareSIP(record_rx=True, headless=True)
+mic = BareSIPMicrophone(sip=sip)
+```
+
+`mic.start()` blocks until `sip.call_established`, then opens a `WavTailReader` on the newest
+rx recording. `mic.read_chunk()` reads and resamples audio to `sample_rate=16000` (default),
+16-bit mono PCM — the format OVOS listener components expect — regardless of the call's actual
+codec rate.
+
+## Wiring `SimpleListener`
+
+`ovos_simple_listener.SimpleListener` drives STT/VAD over a `Microphone` and calls back on
+transcribed utterances:
+
+```python
+from ovos_plugin_manager.stt import OVOSSTTFactory
+from ovos_plugin_manager.vad import OVOSVADFactory
+from ovos_simple_listener import SimpleListener, ListenerCallbacks
+
+
+class Callbacks(ListenerCallbacks):
+    @classmethod
+    def text_callback(cls, utterance, lang):
+        print("caller said:", utterance)
+
+
+listener = SimpleListener(
+    mic=mic, wakeword=None,
+    vad=OVOSVADFactory.create(),
+    stt=OVOSSTTFactory.create(),
+    callbacks=Callbacks(),
+)
+listener.start()
+```
+
+`wakeword=None` means the listener activates on VAD (voice activity) alone, with no wake-word
+required — appropriate for a phone call, where the caller is always addressing the bot.
+
+## End-to-end example
+
+`examples/voice_bot.py` combines all of the above: a `BareSIP` subclass that accepts inbound
+calls, starts a `SimpleListener` over a `BareSIPMicrophone` once the call is established, echoes
+transcribed speech back via `speak()`, and stops the listener when the call ends. Run it with:
+
+```bash
+pip install baresipy[ovos] ovos-stt-plugin-server ovos-vad-plugin-webrtcvad
+python examples/voice_bot.py
+```
+
+(edit the `gateway`/`user`/`pswd` placeholders at the top of the file first, or adapt it to
+registrar-less mode per [docs/direct-calls.md](direct-calls.md)).
+
+## TTS
+
+`speak()`/`say()` need an OPM TTS instance. Pass one explicitly via `BareSIP(tts=...)`, or let
+baresipy create the default lazily (`ovos-tts-plugin-phoonnx`, from the `phoonnx` package) the
+first time `speak()`/`say()` is called without a `tts=` configured. Any object exposing
+`get_tts(text, wav_file) -> (wav_file, phonemes)` works, so any OPM-compatible TTS plugin can be
+swapped in.
+
+## Latency and audio quality notes
+
+SIP calls typically run at narrowband (8kHz, eg. G.711/PCMU) or wideband (16kHz+) sample rates
+depending on the negotiated codec and peer; baresip's default config enables Opus (variable, up
+to 48kHz) and G.711 (8kHz). `BareSIPMicrophone` always resamples to 16kHz mono via
+`baresipy.audio.resample_pcm16` (pure stdlib, no `audioop`/numpy) before handing chunks to the
+listener, since that's the rate most STT/VAD plugins expect — narrowband (8kHz) source audio is
+upsampled and will not gain detail it never had, so STT accuracy on 8kHz legs is inherently lower
+than on wideband calls. There is inherent latency in the pipeline: baresip must decode and write
+each frame to the `sndfile` recording, `WavTailReader` polls for new bytes, and STT/VAD run on
+buffered chunks rather than a true low-latency stream — expect turn-taking on the order of
+seconds, not milliseconds, which is normal for this architecture.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,126 @@
+# Setup
+
+Installing system and python dependencies, getting SIP credentials, and making a first call.
+
+## System dependencies
+
+baresipy drives the real `baresip` binary as a subprocess (via `pexpect`), and uses `ffmpeg`
+(through `pydub`) to convert/resample audio before sending it into a call. Both must be installed
+system-wide before `pip install baresipy`.
+
+### Debian / Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install -y baresip ffmpeg
+```
+
+### Arch Linux
+
+```bash
+sudo pacman -S baresip ffmpeg
+```
+
+### Fedora
+
+```bash
+sudo dnf install -y baresip ffmpeg
+```
+
+Confirm the binary is on `PATH`:
+
+```bash
+baresip -h
+```
+
+## Python install
+
+```bash
+pip install baresipy
+```
+
+or with [uv](https://github.com/astral-sh/uv):
+
+```bash
+uv pip install baresipy
+```
+
+### Extras
+
+| extra | installs | needed for |
+|---|---|---|
+| `baresipy[ovos]` | `ovos-plugin-manager`, `phoonnx`, `ovos-simple-listener` | `speak()`/`say()` default TTS engine, `baresipy.ovos.BareSIPMicrophone`, voice bots (see [docs/ovos-integration.md](ovos-integration.md)) |
+| `baresipy[test]` | `pytest`, `pytest-cov` | running the test suite (see [docs/testing.md](testing.md)) |
+
+`baresipy` itself never requires `ovos-plugin-manager` to be installed — `import baresipy` works
+without it. `import baresipy.ovos` (or calling `speak()`/`say()` without passing `tts=`) raises an
+`ImportError` naming the `[ovos]` extra if the dependency is missing.
+
+## SIP account requirements
+
+`BareSIP(user, pwd, gateway, transport="udp")` registers the account:
+
+```
+sip:<user>@<gateway>;transport=<transport>;auth_pass=<pwd>
+```
+
+- **`user`** — the SIP username/extension your provider or PBX gave you (eg. `1001`).
+- **`pwd`** — the SIP account password/secret for that user.
+- **`gateway`** — the SIP registrar/proxy host, eg. `sip.example.com` or an IP address. Once
+  registered, bare `call(number)` targets resolve against this gateway
+  (`sip:<number>@<gateway>`); pass a full `sip:` URI to `call()` to dial elsewhere.
+- **`transport`** — `"udp"` (default) or `"tcp"`, must match what your provider expects.
+
+If you don't have a SIP account at all, you don't need one — see
+[docs/direct-calls.md](direct-calls.md) for registrar-less peer-to-peer calling.
+
+`login_options` lets you append extra SIP URI parameters to the registration line, eg.
+`login_options="transport=tls"`-style flags your provider requires beyond the basics.
+
+## Verifying with a first call
+
+```python
+from baresipy import BareSIP
+from time import sleep
+
+b = BareSIP("your_user", "your_password", "your_sip_gateway.example", debug=True)
+b.call("some_number_or_user@your_sip_gateway.example")
+
+while b.running:
+    sleep(0.5)
+    if b.call_established:
+        b.speak("hello world")
+        b.hang()
+        b.quit()
+        break
+```
+
+`debug=True` logs every raw line baresip prints, which is the fastest way to see what's actually
+happening (registration, ringing, codec negotiation, hangup reason) while you're getting a
+first call working.
+
+## Troubleshooting
+
+**No sound card / running on a server or in a container** — pass `headless=True`. This swaps
+baresip's audio source for `ausine` (a synthesized sine tone) and its player for `aufile`
+(writes to `/dev/null`), so no ALSA/PulseAudio device is required. This is the mode used by
+servers, containers, and voice bots — see [docs/docker.md](docker.md).
+
+**`failed to set audio-source (Function not implemented)`** (or `No such device`) — baresip
+tried to open a real sound driver that isn't available in the environment. Either install/fix
+the audio stack, or switch to `headless=True`. `BareSIP.handle_error()` treats
+`"failed to set audio-source (No such device)"` as an audio-stream failure and hangs up the call
+automatically; other audio-source errors are only logged, so watch for them with `debug=True`.
+
+**Login failures** — `BareSIP.handle_login_failure()` is called (and, by default, `quit()`s the
+instance) whenever baresip logs `ua: SIP register failed:`, `401 Unauthorized`,
+`Register: Destination address required`, or `Register: Connection timed out`. Double check
+`user`/`pwd`/`gateway`/`transport` against what your provider issued, and run with `debug=True`
+to see the exact rejection line.
+
+**NAT / firewall** — baresip needs inbound UDP (or TCP, matching `transport`) on port `5060` for
+SIP signalling, plus an RTP port range for the actual audio (baresip's default config listens on
+an ephemeral range; see the commented `#rtp_ports 10000-20000` line in
+[docs/configuration.md](configuration.md)). If calls register but audio never flows, or inbound
+calls never arrive, check that both are reachable through any firewall/NAT between the machine
+and the SIP gateway/peer.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,83 @@
+# Testing
+
+Running the unit suite, the docker e2e rig, and adding new tests.
+
+## Unit suite
+
+```bash
+uv venv .venv
+VIRTUAL_ENV=$PWD/.venv uv pip install -e .[test]
+VIRTUAL_ENV=$PWD/.venv .venv/bin/pytest test/
+```
+
+or with plain `pip`:
+
+```bash
+pip install -e .[test]
+pytest test/
+```
+
+`pyproject.toml` sets `addopts = "-m 'not e2e'"`, so end-to-end tests (which need docker and are
+slow) are deselected by default and only unit tests run.
+
+Test files, by area:
+
+- `test/test_state_machine.py` — `BareSIP._handle_output_line()` parsing/state transitions
+- `test/test_config.py` — `render_config()` / `ensure_sndfile_recording()`
+- `test/test_audio.py` — `WavTailReader`
+- `test/test_resample.py` — `resample_pcm16()`
+- `test/test_tts.py` — `get_default_tts()`
+- `test/test_contacts.py` — `ContactList`
+- `test/test_import.py`, `test/test_ovos_optional.py` — import-time behavior, incl. that
+  `import baresipy` never requires `ovos-plugin-manager`, and that `import baresipy.ovos` raises
+  a clear `ImportError` naming the `[ovos]` extra when it's missing
+
+## End-to-end rig
+
+`test/e2e/` drives the two-container call described in [docs/docker.md](docker.md) (real
+`baresip` processes, real registrar-less SIP/RTP over a docker network) and asserts on the
+results:
+
+```bash
+pytest test/ -m e2e
+```
+
+Requires docker and docker compose to be available; not run by default (see `addopts` above).
+
+## Adding tests
+
+Most unit tests don't need a real baresip process. Use the fake-`pexpect` pattern from
+`test/test_state_machine.py` to construct a `BareSIP` instance without spawning anything or
+touching `~/.baresipy`:
+
+```python
+import tempfile
+from unittest.mock import patch, MagicMock
+import baresipy
+
+
+def make_baresip(**kwargs):
+    kwargs.setdefault("autostart", False)
+    kwargs.setdefault("config_path", tempfile.mkdtemp())
+    with patch.object(baresipy.pexpect, "spawn") as mock_spawn:
+        mock_spawn.return_value = MagicMock()
+        bs = baresipy.BareSIP(**kwargs)
+    return bs
+```
+
+`autostart=False` skips starting the event-loop thread; `config_path` points at a throwaway temp
+directory so the test never reads or writes the real `~/.baresipy/config`. With the instance
+constructed this way, feed it raw baresip output lines directly and assert on the resulting state
+or on which `handle_*` method fired:
+
+```python
+bs = make_baresip()
+with patch.object(bs, "handle_ready") as h:
+    bs._handle_output_line("baresip is ready.")
+h.assert_called_once()
+assert bs.ready
+```
+
+Tests live under `test/` (a single flat test directory, not `tests/`). New e2e-only tests should
+be marked `@pytest.mark.e2e` (registered in `pyproject.toml`) so they're excluded from the default
+run.

--- a/examples/contact_list.py
+++ b/examples/contact_list.py
@@ -1,3 +1,11 @@
+"""Local contact list.
+
+Demonstrates baresipy.contacts.ContactList: a local JSON-backed contact
+store (~/.baresip/contacts.db by default), independent of BareSIP itself.
+
+Required installs:
+    pip install baresipy
+"""
 from baresipy.contacts import ContactList
 
 db = ContactList()

--- a/examples/events.py
+++ b/examples/events.py
@@ -1,3 +1,12 @@
+"""Registered-account answering bot.
+
+Subclasses BareSIP to auto-accept incoming calls and speak a joke before
+hanging up, demonstrating the handle_incoming_call/handle_call_established
+event hooks.
+
+Required installs:
+    pip install baresipy[ovos] pyjokes
+"""
 from baresipy import BareSIP
 from time import sleep
 from pyjokes import get_joke  # pip install pyjokes

--- a/examples/scripted_call.py
+++ b/examples/scripted_call.py
@@ -1,3 +1,11 @@
+"""Registered-account scripted call.
+
+Dials out to a number, sends DTMF and speaks two sentences with TTS once the
+call is established, then hangs up.
+
+Required installs:
+    pip install baresipy[ovos]   # for the default speak() TTS engine
+"""
 from baresipy import BareSIP
 from time import sleep
 


### PR DESCRIPTION
Full setup documentation for the modernized library.

- `README.md` rewritten: pitch, install, three quickstarts (scripted call, answering bot, OVOS voice bot), feature/extras tables, docs index, credits preserved.
- New `docs/`:
  - `setup.md` — per-distro system deps, pip/uv install, extras, SIP account fields, first call, troubleshooting (headless audio, login failures, NAT/RTP ports)
  - `configuration.md` — config dir, `render_config()`, full constructor kwarg reference
  - `direct-calls.md` — registrar-less mode and the inbound direct-call matching rules
  - `ovos-integration.md` — end-to-end voice-bot walkthrough (plugins, mycroft.conf, `BareSIPMicrophone` + `SimpleListener`, TTS, codec/latency notes)
  - `docker.md` — GHCR image, build args, ports, e2e rig
  - `testing.md` — unit suite, e2e rig, fake-pexpect test pattern
- `AGENTS.md` refreshed to the current module layout and workflows; examples all carry usage docstrings.

## Verification
`ruff` clean; unit suite 58 passed (e2e deselected) in a fresh venv. All documented signatures cross-checked against the code; OVOS plugin package names verified against the org index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
