### PR TITLE
feat: prefer the baresip-binary bundled executable when installed

### DIFF
--- a/baresipy/__init__.py
+++ b/baresipy/__init__.py
@@ -14,8 +14,23 @@ from baresipy.config import render_config, ensure_sndfile_recording
 from baresipy.audio import WavTailReader
 from os.path import expanduser, join, isfile, isdir, getmtime
 from os import makedirs
+from shutil import which
 import signal
 import re
+
+
+def _find_baresip_binary() -> str:
+    """Resolve the baresip executable to run.
+
+    Prefers the self-contained binary shipped by the optional
+    ``baresip-binary`` package (no system ``baresip`` install required);
+    falls back to a system-installed ``baresip`` on PATH.
+    """
+    try:
+        from baresip_binary import BARESIP_BIN
+        return BARESIP_BIN
+    except ImportError:
+        return which("baresip") or "baresip"
 
 logging.getLogger("urllib3.connectionpool").setLevel("WARN")
 logging.getLogger("pydub.converter").setLevel("WARN")
@@ -111,7 +126,7 @@ class BareSIP(Thread):
         self.audio = None
         self._ts = None
         self._block_until_ready = block
-        self.baresip = pexpect.spawn('baresip -f ' + self.config_path)
+        self.baresip = pexpect.spawn(_find_baresip_binary() + ' -f ' + self.config_path)
         super().__init__()
         if autostart:
             self.start()


### PR DESCRIPTION
Resolves the `baresip` executable through an optional companion package before falling back to the system PATH: if `baresip-binary` (a platform wheel shipping a self-contained baresip 4.9.0 with menu/account/g711/ausine/aufile/sndfile/stdio/uuid statically built in) is installed, its executable is used, removing the `apt install baresip` requirement. Without it, behavior is unchanged.

The companion package publishes separately; this fallback chain is inert until it is installed.

## Verification
Full unit suite green (58 passed); ruff clean. The bundled binary itself was verified on a docker host: wheel installed in a fresh venv, `baresip -h` runs, sndfile module present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)