### PR TITLE
fix: cap httpx below 1.0 in the test extra

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'baresipy'
       test_path: 'test/'
-      install_extras: ''
+      test_extras: 'test'
       min_coverage: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ test = [
     "pytest",
     "pytest-cov",
     "fastapi",
-    "httpx",
+    "httpx>=0.27,<1.0",
     "python-multipart",
     "uvicorn",
 ]


### PR DESCRIPTION
httpx 1.0 removed `BaseTransport`, which starlette's `TestClient` still imports — CI test collection failed on every python version after #40. Pins `httpx>=0.27,<1.0` in the test extra until starlette supports httpx 1.x.

Verified locally in a fresh venv: full suite green with the pinned resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)