### PR TITLE
ci: run the live e2e call test on pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,22 @@
+name: E2E call test
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test deps
+        run: pip install -e .[test]
+      - name: Run the live call test
+        run: pytest test/e2e/test_call.py -m e2e -v
+      - name: Dump compose logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.e2e.yml logs || true


### PR DESCRIPTION
Runs the registrar-less two-container call test (`test/e2e/test_call.py`) on every PR — the docker compose rig builds the image, places a real call, and asserts establishment, DTMF delivery and non-silent RTP capture. This is the regression guard for the baresip stdout state machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)