### PR TITLE
feat: interruptible playback, transfer, caller identity, login retry, TLS/SRTP

### DIFF
--- a/baresipy/__init__.py
+++ b/baresipy/__init__.py
@@ -6,12 +6,14 @@ from pydub import AudioSegment
 import tempfile
 import logging
 import subprocess
+import threading
 from threading import Thread
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 from baresipy.utils.log import LOG
 from baresipy.tts import get_default_tts
 from baresipy.config import render_config, ensure_sndfile_recording
 from baresipy.audio import WavTailReader
+from baresipy.call import CallInfo, parse_sip_uri
 from os.path import expanduser, join, isfile, isdir, getmtime
 from os import makedirs
 from shutil import which
@@ -47,7 +49,27 @@ class BareSIP(Thread):
                  headless: bool = False,
                  audio_driver: str = "alsa,default",
                  record_rx: bool = False,
-                 recording_path: Optional[str] = None):
+                 recording_path: Optional[str] = None,
+                 max_login_retries: int = 0,
+                 login_retry_delay: float = 15.0,
+                 media_encryption: Optional[str] = None,
+                 sip_cafile: Optional[str] = None):
+        """
+        :param max_login_retries: if > 0, retry registration this many
+            times (with `login_retry_delay` seconds between attempts)
+            before giving up and calling `handle_login_failure()` (which
+            quits). 0 (default) preserves the original behaviour of
+            quitting immediately on the first registration failure.
+        :param login_retry_delay: seconds to wait between registration
+            retries, only used when `max_login_retries > 0`.
+        :param media_encryption: one of "srtp"/"srtp-mand"/"srtp-mandf"/
+            "dtls_srtp". If set, appended to the SIP account line as
+            `;mediaenc=<value>` and implies `enable_srtp=True` when
+            rendering the config.
+        :param sip_cafile: path to a CA bundle used to verify the SIP
+            server certificate. Required for real verification when
+            `transport="tls"` is used.
+        """
         config_path = config_path or join("~", ".baresipy")
         self.config_path = expanduser(config_path)
         if not isdir(self.config_path):
@@ -69,8 +91,10 @@ class BareSIP(Thread):
             LOG.info("config loaded from " + self.config_path + "/config")
             self.updated_config = False
         else:
-            self.config = render_config(audio_driver=audio_driver,
-                                         headless=headless)
+            self.config = render_config(
+                audio_driver=audio_driver, headless=headless,
+                sip_cafile=sip_cafile,
+                enable_srtp=bool(media_encryption))
             self.updated_config = True
 
         self._original_config = str(self.config)
@@ -109,12 +133,16 @@ class BareSIP(Thread):
         self.gateway = gateway
         self.transport = transport
         self.tts = tts
+        self.media_encryption = media_encryption
+        self.sip_cafile = sip_cafile
         self._login = None
         if self.gateway:
             self._login = "sip:{u}@{g};transport={t};auth_pass={p}".format(
                 u=self.user, p=self.pwd, g=self.gateway, t=self.transport)
             if login_options:
                 self._login += ";{o}".format(o=login_options)
+            if media_encryption:
+                self._login += ";mediaenc={e}".format(e=media_encryption)
         self._prev_output = ""
         self._local_ua_added = False
         self.running = False
@@ -126,6 +154,12 @@ class BareSIP(Thread):
         self.audio = None
         self._ts = None
         self._block_until_ready = block
+        self._tx_interrupted = False
+        self.current_call_info: Optional[CallInfo] = None
+        self.call_history: List[CallInfo] = []
+        self.max_login_retries = max_login_retries
+        self.login_retry_delay = login_retry_delay
+        self._login_retry_count = 0
         self.baresip = pexpect.spawn(_find_baresip_binary() + ' -f ' + self.config_path)
         super().__init__()
         if autostart:
@@ -204,6 +238,21 @@ class BareSIP(Thread):
             self.do_command("/resume")
         else:
             LOG.error("No active call to resume")
+
+    def transfer(self, uri: str) -> None:
+        """Transfer (blind/attended-lite) the active call to `uri` using
+        baresip's `menu` module dynamic `/transfer` command (SIP REFER)."""
+        if not self.current_call:
+            LOG.error("No active call to transfer")
+            return
+        LOG.info("Transferring call to: " + uri)
+        self.do_command("/transfer " + uri)
+
+    def handle_transfer_ok(self) -> None:
+        LOG.info("Call transfer succeeded")
+
+    def handle_transfer_failed(self, reason: str) -> None:
+        LOG.warning("Call transfer failed: " + reason)
 
     def mute_mic(self) -> None:
         if not self.call_established:
@@ -332,7 +381,7 @@ class BareSIP(Thread):
         ToneGenerator().dtmf_to_wave(number, dtmf)
         self.send_audio(dtmf)
 
-    def speak(self, speech: str) -> None:
+    def speak(self, speech: str, blocking: bool = True) -> None:
         if not self.call_established:
             LOG.error("Speaking without an active call!")
             return
@@ -340,24 +389,65 @@ class BareSIP(Thread):
         if self.tts is None:
             raise RuntimeError(
                 "no TTS configured - pass tts= or install baresipy[ovos]")
-        LOG.info("Sending TTS for " + speech)
-        wav_file = join(tempfile.gettempdir(), "pybaresip_speak.wav")
-        wav_file, phonemes = self.tts.get_tts(speech, wav_file)
-        self.send_audio(wav_file)
+        # dumb sentence split - no NLP, just enough to allow barge-in
+        # between sentences
+        sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", speech)
+                     if s.strip()]
+        if not sentences:
+            return
+        self._tx_interrupted = False
+        for sentence in sentences:
+            if self._tx_interrupted or not self.call_established:
+                self.handle_audio_interrupted()
+                return
+            LOG.info("Sending TTS for " + sentence)
+            wav_file = join(tempfile.gettempdir(), "pybaresip_speak.wav")
+            wav_file, phonemes = self.tts.get_tts(sentence, wav_file)
+            self.send_audio(wav_file, block=blocking)
+            if self._tx_interrupted or not self.call_established:
+                self.handle_audio_interrupted()
+                return
         sleep(0.5)
 
-    def send_audio(self, wav_file: str) -> None:
+    def handle_audio_interrupted(self) -> None:
+        LOG.debug("Audio playback interrupted")
+
+    def stop_audio(self) -> None:
+        """Immediately revert the audio source, interrupting any in-flight
+        `send_audio`/`speak` playback (barge-in)."""
+        LOG.info("Stopping audio playback")
+        self._tx_interrupted = True
+        self.do_command("/ausrc " + self._default_ausrc)
+
+    def send_audio(self, wav_file: str, block: bool = True) -> float:
         if not self.call_established:
             LOG.error("Can't send audio without an active call!")
-            return
+            return 0.0
+        self._tx_interrupted = False
         wav_file, duration = self.convert_audio(wav_file)
         # send audio stream
         LOG.info("transmitting audio")
         self.do_command("/ausrc aufile," + wav_file)
-        # wait till playback ends
-        sleep(duration - 0.5)
-        # avoid baresip exiting
-        self.do_command("/ausrc " + self._default_ausrc)
+        if block:
+            # wait till playback ends, in small steps so a barge-in
+            # (stop_audio) or call drop can cut this short
+            deadline = _time() + max(duration - 0.5, 0)
+            while _time() < deadline:
+                if self._tx_interrupted or not self.call_established:
+                    break
+                sleep(0.1)
+            if not self._tx_interrupted and self.call_established:
+                # avoid baresip exiting
+                self.do_command("/ausrc " + self._default_ausrc)
+        else:
+            timer = threading.Timer(duration, self._revert_audio_source)
+            timer.daemon = True
+            timer.start()
+        return duration
+
+    def _revert_audio_source(self) -> None:
+        if not self._tx_interrupted:
+            self.do_command("/ausrc " + self._default_ausrc)
 
     @staticmethod
     def convert_audio(input_file: str, outfile: Optional[str] = None,
@@ -458,6 +548,20 @@ class BareSIP(Thread):
         LOG.error("Log in failed!")
         self.quit()
 
+    def handle_login_retry(self, attempt: int) -> None:
+        LOG.info(f"Retrying registration (attempt {attempt}/"
+                  f"{self.max_login_retries})")
+
+    def _schedule_login_retry(self) -> None:
+        self._login_retry_count += 1
+        if self._login_retry_count > self.max_login_retries:
+            self.handle_login_failure()
+            return
+        self.handle_login_retry(self._login_retry_count)
+        timer = threading.Timer(self.login_retry_delay, self.login)
+        timer.daemon = True
+        timer.start()
+
     def handle_ready(self) -> None:
         LOG.info("Ready for instructions")
 
@@ -473,6 +577,18 @@ class BareSIP(Thread):
 
     def handle_dtmf_received(self, char: str, duration: int) -> None:
         LOG.info("Received DTMF symbol '{0}' duration={1}".format(char, duration))
+        if self.current_call_info is not None:
+            self.current_call_info.dtmf += char
+
+    def _finalize_call_info(self, reason: Optional[str] = None) -> None:
+        if self.current_call_info is None:
+            return
+        self.current_call_info.ended = _time()
+        self.current_call_info.reason = reason
+        self.call_history.append(self.current_call_info)
+        if len(self.call_history) > 100:
+            self.call_history.pop(0)
+        self.current_call_info = None
 
     def handle_error(self, error: str) -> None:
         LOG.error(error)
@@ -495,18 +611,26 @@ class BareSIP(Thread):
             self._handle_no_accounts()
         elif "All 1 useragent registered successfully!" in out:
             self.ready = True
+            self._login_retry_count = 0
             self.handle_login_success()
         elif "ua: SIP register failed:" in out or \
                 "401 Unauthorized" in out or \
                 "Register: Destination address required" in out or \
                 "Register: Connection timed out" in out:
             self.handle_error(out)
-            self.handle_login_failure()
+            if self.max_login_retries > 0:
+                self._schedule_login_retry()
+            else:
+                self.handle_login_failure()
         elif "Incoming call from: " in out:
             num = out.split("Incoming call from: ")[
                 1].split(" - (press 'a' to accept)")[0].strip()
             self.current_call = num
             self._call_status = "INCOMING"
+            user, host = parse_sip_uri(num)
+            self.current_call_info = CallInfo(
+                uri=num, user=user, host=host, direction="in",
+                started=_time())
             self.handle_incoming_call(num)
         elif "call: rejecting incoming call from " in out:
             num = out.split("rejecting incoming call from ")[1].split(" ")[0].strip()
@@ -519,6 +643,10 @@ class BareSIP(Thread):
         elif "call: connecting to " in out:
             n = out.split("call: connecting to '")[1].split("'")[0]
             self.current_call = n
+            user, host = parse_sip_uri(n)
+            self.current_call_info = CallInfo(
+                uri=n, user=user, host=host, direction="out",
+                started=_time())
             self.handle_call_start()
             status = "OUTGOING"
             self.handle_call_status(status)
@@ -542,6 +670,7 @@ class BareSIP(Thread):
             self._call_status = status
             self.handle_call_timestamp(duration)
             self.mic_muted = False
+            self._finalize_call_info(reason=duration)
         elif "call muted" in out:
             self.mic_muted = True
             self.handle_mic_muted()
@@ -556,6 +685,7 @@ class BareSIP(Thread):
             self._call_status = status
             self.handle_call_ended(reason, number)
             self.mic_muted = False
+            self._finalize_call_info(reason=reason)
         elif "(no active calls)" in out:
             status = "DISCONNECTED"
             self.handle_call_status(status)
@@ -579,6 +709,21 @@ class BareSIP(Thread):
         elif "terminated by signal" in out or "ua: stop all" in \
                 out:
             self.running = False
+        elif "transfer" in out.lower():
+            # baresip (modules/menu/menu.c) has no dedicated "transfer
+            # succeeded" line - success is only implied by the transferee
+            # call reaching ESTABLISHED - so match generously here:
+            #   "menu: transferring call <id> to '<uri>'" -> initiation
+            #       accepted, treated as ok
+            #   anything else containing "transfer" + fail/error -> failed
+            lowered = out.lower()
+            if "fail" in lowered or "error" in lowered:
+                reason = out.strip()
+                self.handle_transfer_failed(reason)
+            elif "transferring call" in lowered:
+                self.handle_transfer_ok()
+            else:
+                self.handle_unhandled_output(out)
         elif "DTMF" in out:
             # baresip logs DTMF differently per transport:
             #   legacy:   received DTMF: '1' (duration=250)

--- a/baresipy/call.py
+++ b/baresipy/call.py
@@ -1,0 +1,39 @@
+"""Call metadata helpers.
+
+Small, dependency-free data structures describing a single call, plus a SIP
+URI parser used to populate them.
+"""
+from dataclasses import dataclass
+from typing import Optional, Tuple
+import re
+
+_SIP_URI_RE = re.compile(
+    r"^(?:sip:)?(?:(?P<user>[^@:;]+)@)?(?P<host>[^@:;]+)(?::\d+)?(?:;.*)?$")
+
+
+def parse_sip_uri(uri: str) -> Tuple[Optional[str], Optional[str]]:
+    """Parse a SIP URI (or bare `user@host`) into `(user, host)`.
+
+    Handles `sip:user@host[:port][;params]` and bare `user@host` forms.
+    Missing parts are returned as `None`. Best-effort - malformed input
+    simply yields `(None, None)`.
+    """
+    if not uri:
+        return None, None
+    uri = uri.strip()
+    match = _SIP_URI_RE.match(uri)
+    if not match:
+        return None, None
+    return match.group("user"), match.group("host")
+
+
+@dataclass
+class CallInfo:
+    uri: str
+    user: Optional[str]
+    host: Optional[str]
+    direction: str  # "in" | "out"
+    started: float
+    ended: Optional[float] = None
+    reason: Optional[str] = None
+    dtmf: str = ""

--- a/baresipy/config.py
+++ b/baresipy/config.py
@@ -251,7 +251,9 @@ def render_config(audio_driver: str = "alsa,default",
                    headless: bool = False,
                    audio_path: Optional[str] = None,
                    enable_sndfile: bool = False,
-                   snd_path: Optional[str] = None) -> str:
+                   snd_path: Optional[str] = None,
+                   sip_cafile: Optional[str] = None,
+                   enable_srtp: bool = False) -> str:
     """Render a baresip config file from the DEFAULT template.
 
     :param audio_driver: value passed to `audio_source`/`audio_player`/
@@ -266,6 +268,10 @@ def render_config(audio_driver: str = "alsa,default",
         baresip records call audio (rx/tx wav files) into `snd_path`
     :param snd_path: directory to write call recordings into, required if
         `enable_sndfile` is True
+    :param sip_cafile: if set, points `sip_cafile` at this path, so baresip
+        can verify the server certificate when `transport="tls"` is used
+    :param enable_srtp: if True, load the `srtp.so` module so SRTP media
+        encryption is available (see `media_encryption` on `BareSIP`)
     """
     config = DEFAULT
 
@@ -309,5 +315,17 @@ def render_config(audio_driver: str = "alsa,default",
         if not snd_path:
             raise ValueError("snd_path is required when enable_sndfile=True")
         config = ensure_sndfile_recording(config, snd_path)
+
+    if sip_cafile:
+        if "#sip_certificate	cert.pem" in config:
+            config = config.replace(
+                "#sip_certificate	cert.pem",
+                "#sip_certificate	cert.pem\nsip_cafile\t\t" + sip_cafile)
+        else:
+            config += "\nsip_cafile\t\t" + sip_cafile + "\n"
+
+    if enable_srtp:
+        config = config.replace(
+            "#module			srtp.so", "module			srtp.so")
 
     return config

--- a/test/test_call_info.py
+++ b/test/test_call_info.py
@@ -1,0 +1,125 @@
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+import baresipy
+from baresipy.call import CallInfo, parse_sip_uri
+
+
+def make_baresip(**kwargs):
+    kwargs.setdefault("autostart", False)
+    kwargs.setdefault("config_path", tempfile.mkdtemp())
+    with patch.object(baresipy.pexpect, "spawn") as mock_spawn:
+        mock_spawn.return_value = MagicMock()
+        bs = baresipy.BareSIP(**kwargs)
+    return bs
+
+
+class TestParseSipUri(unittest.TestCase):
+    def test_full_uri_with_port(self):
+        self.assertEqual(
+            parse_sip_uri("sip:alice@example.com:5060"),
+            ("alice", "example.com"))
+
+    def test_full_uri_with_params(self):
+        self.assertEqual(
+            parse_sip_uri("sip:alice@example.com;transport=tcp"),
+            ("alice", "example.com"))
+
+    def test_full_uri_with_port_and_params(self):
+        self.assertEqual(
+            parse_sip_uri("sip:alice@example.com:5061;transport=tls"),
+            ("alice", "example.com"))
+
+    def test_bare_user_host(self):
+        self.assertEqual(
+            parse_sip_uri("alice@example.com"), ("alice", "example.com"))
+
+    def test_missing_user(self):
+        self.assertEqual(
+            parse_sip_uri("sip:example.com"), (None, "example.com"))
+
+    def test_empty_string(self):
+        self.assertEqual(parse_sip_uri(""), (None, None))
+
+    def test_none_like_falsy(self):
+        self.assertEqual(parse_sip_uri(None), (None, None))
+
+
+class TestCallInfoLifecycle(unittest.TestCase):
+    def setUp(self):
+        self.bs = make_baresip()
+
+    def test_incoming_call_creates_call_info_in_direction(self):
+        with patch.object(self.bs, "handle_incoming_call"):
+            self.bs._handle_output_line(
+                "Incoming call from: sip:bob@example.com - "
+                "(press 'a' to accept)")
+        info = self.bs.current_call_info
+        self.assertIsNotNone(info)
+        self.assertEqual(info.direction, "in")
+        self.assertEqual(info.user, "bob")
+        self.assertEqual(info.host, "example.com")
+
+    def test_outgoing_call_creates_call_info_out_direction(self):
+        with patch.object(self.bs, "handle_call_start"):
+            self.bs._handle_output_line(
+                "call: connecting to 'sip:carol@example.com'...")
+        info = self.bs.current_call_info
+        self.assertIsNotNone(info)
+        self.assertEqual(info.direction, "out")
+        self.assertEqual(info.user, "carol")
+        self.assertEqual(info.host, "example.com")
+
+    def test_dtmf_appends_to_current_call_info(self):
+        with patch.object(self.bs, "handle_call_start"):
+            self.bs._handle_output_line(
+                "call: connecting to 'sip:carol@example.com'...")
+        self.bs._handle_output_line("received DTMF: '1' (duration=250)")
+        self.bs._handle_output_line("received DTMF: '2' (duration=250)")
+        self.assertEqual(self.bs.current_call_info.dtmf, "12")
+
+    def test_dtmf_without_active_call_does_not_crash(self):
+        self.assertIsNone(self.bs.current_call_info)
+        # should simply not append anywhere
+        self.bs._handle_output_line("received DTMF: '5' (duration=250)")
+        self.assertIsNone(self.bs.current_call_info)
+
+    def test_call_end_appends_to_history_and_clears_current(self):
+        with patch.object(self.bs, "handle_call_start"):
+            self.bs._handle_output_line(
+                "call: connecting to 'sip:carol@example.com'...")
+        with patch.object(self.bs, "handle_call_timestamp"):
+            self.bs._handle_output_line(
+                "x: Call with sip:carol@example.com terminated "
+                "(duration: 00:00:05)")
+        self.assertIsNone(self.bs.current_call_info)
+        self.assertEqual(len(self.bs.call_history), 1)
+        entry = self.bs.call_history[0]
+        self.assertEqual(entry.direction, "out")
+        self.assertIsNotNone(entry.ended)
+        self.assertEqual(entry.reason, "00:00:05")
+
+    def test_session_closed_appends_to_history(self):
+        with patch.object(self.bs, "handle_incoming_call"):
+            self.bs._handle_output_line(
+                "Incoming call from: sip:x - (press 'a' to accept)")
+        with patch.object(self.bs, "handle_call_ended"):
+            self.bs._handle_output_line("sip:x: session closed: 200")
+        self.assertIsNone(self.bs.current_call_info)
+        self.assertEqual(len(self.bs.call_history), 1)
+        self.assertEqual(self.bs.call_history[0].reason, "200")
+
+    def test_history_capped_at_100_entries(self):
+        for i in range(105):
+            self.bs.current_call_info = CallInfo(
+                uri=f"sip:{i}@x", user=str(i), host="x",
+                direction="out", started=0.0)
+            self.bs._finalize_call_info(reason="done")
+        self.assertEqual(len(self.bs.call_history), 100)
+        # oldest entries dropped, newest kept
+        self.assertEqual(self.bs.call_history[-1].user, "104")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_call_primitives.py
+++ b/test/test_call_primitives.py
@@ -1,0 +1,173 @@
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+import baresipy
+
+
+def make_baresip(**kwargs):
+    kwargs.setdefault("autostart", False)
+    kwargs.setdefault("config_path", tempfile.mkdtemp())
+    with patch.object(baresipy.pexpect, "spawn") as mock_spawn:
+        mock_spawn.return_value = MagicMock()
+        bs = baresipy.BareSIP(**kwargs)
+    return bs
+
+
+class TestStopAudio(unittest.TestCase):
+    def setUp(self):
+        self.bs = make_baresip()
+        self.bs.ready = True
+
+    def test_stop_audio_flips_flag_and_reverts_source(self):
+        with patch.object(self.bs.baresip, "sendline") as h:
+            self.bs.stop_audio()
+        self.assertTrue(self.bs._tx_interrupted)
+        h.assert_called_once_with("/ausrc " + self.bs._default_ausrc)
+
+
+class TestSendAudio(unittest.TestCase):
+    def setUp(self):
+        self.bs = make_baresip()
+        self.bs.ready = True
+        self.bs.current_call = "sip:x@y"
+        self.bs._call_status = "ESTABLISHED"
+
+    def test_blocking_exits_early_on_interruption(self):
+        with patch.object(self.bs, "convert_audio",
+                           return_value=("/tmp/foo.wav", 5.0)), \
+                patch.object(self.bs.baresip, "sendline"), \
+                patch("baresipy.sleep") as mock_sleep:
+            def interrupt(*a, **kw):
+                self.bs._tx_interrupted = True
+            mock_sleep.side_effect = interrupt
+            duration = self.bs.send_audio("foo.wav", block=True)
+        self.assertEqual(duration, 5.0)
+        # only one sleep(0.1) call happened before the flag broke the loop
+        mock_sleep.assert_called_once_with(0.1)
+
+    def test_blocking_completes_normally(self):
+        with patch.object(self.bs, "convert_audio",
+                           return_value=("/tmp/foo.wav", 0.2)), \
+                patch.object(self.bs.baresip, "sendline") as h, \
+                patch("baresipy.sleep"):
+            duration = self.bs.send_audio("foo.wav", block=True)
+        self.assertEqual(duration, 0.2)
+        calls = [c.args[0] for c in h.call_args_list]
+        self.assertIn("/ausrc aufile,/tmp/foo.wav", calls)
+        self.assertIn("/ausrc " + self.bs._default_ausrc, calls)
+
+    def test_non_blocking_schedules_timer(self):
+        with patch.object(self.bs, "convert_audio",
+                           return_value=("/tmp/foo.wav", 1.0)), \
+                patch.object(self.bs.baresip, "sendline") as h, \
+                patch("baresipy.threading.Timer") as mock_timer:
+            timer_instance = MagicMock()
+            mock_timer.return_value = timer_instance
+            duration = self.bs.send_audio("foo.wav", block=False)
+        self.assertEqual(duration, 1.0)
+        mock_timer.assert_called_once_with(1.0, self.bs._revert_audio_source)
+        self.assertTrue(timer_instance.daemon)
+        timer_instance.start.assert_called_once()
+        h.assert_called_once_with("/ausrc aufile,/tmp/foo.wav")
+
+    def test_revert_audio_source_skipped_when_interrupted(self):
+        self.bs._tx_interrupted = True
+        with patch.object(self.bs.baresip, "sendline") as h:
+            self.bs._revert_audio_source()
+        h.assert_not_called()
+
+    def test_revert_audio_source_runs_when_not_interrupted(self):
+        self.bs._tx_interrupted = False
+        with patch.object(self.bs.baresip, "sendline") as h:
+            self.bs._revert_audio_source()
+        h.assert_called_once_with("/ausrc " + self.bs._default_ausrc)
+
+
+class _FakeTTS:
+    def __init__(self):
+        self.calls = []
+
+    def get_tts(self, text, wav_file):
+        self.calls.append(text)
+        return wav_file, None
+
+
+class TestSpeak(unittest.TestCase):
+    def setUp(self):
+        self.bs = make_baresip()
+        self.bs.ready = True
+        self.bs.current_call = "sip:x@y"
+        self.bs._call_status = "ESTABLISHED"
+        self.tts = _FakeTTS()
+        self.bs.tts = self.tts
+
+    def test_multiple_sentences_produce_multiple_send_calls(self):
+        with patch.object(self.bs, "send_audio",
+                           return_value=0.1) as sa, \
+                patch("baresipy.sleep"):
+            self.bs.speak("Hello there. How are you? Great!")
+        self.assertEqual(len(self.tts.calls), 3)
+        self.assertEqual(sa.call_count, 3)
+
+    def test_interruption_between_sentences_stops_remaining(self):
+        call_count = {"n": 0}
+
+        def fake_send_audio(wav_file, block=True):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                self.bs._tx_interrupted = True
+            return 0.1
+
+        with patch.object(self.bs, "send_audio",
+                           side_effect=fake_send_audio), \
+                patch.object(self.bs, "handle_audio_interrupted") as hi, \
+                patch("baresipy.sleep"):
+            self.bs.speak("Sentence one. Sentence two. Sentence three.")
+        self.assertEqual(call_count["n"], 1)
+        hi.assert_called_once()
+
+    def test_no_active_call_logs_and_returns(self):
+        self.bs._call_status = None
+        with patch.object(self.bs, "send_audio") as sa:
+            self.bs.speak("hello")
+        sa.assert_not_called()
+
+
+class TestTransfer(unittest.TestCase):
+    def setUp(self):
+        self.bs = make_baresip()
+        self.bs.ready = True
+
+    def test_no_active_call_does_not_send_transfer(self):
+        self.bs.current_call = None
+        with patch.object(self.bs.baresip, "sendline") as h:
+            self.bs.transfer("sip:target@example.com")
+        h.assert_not_called()
+
+    def test_active_call_sends_transfer_command(self):
+        self.bs.current_call = "sip:x@y"
+        with patch.object(self.bs.baresip, "sendline") as h:
+            self.bs.transfer("sip:target@example.com")
+        h.assert_called_once_with("/transfer sip:target@example.com")
+
+    def test_transfer_ok_line_fires_hook(self):
+        with patch.object(self.bs, "handle_transfer_ok") as h:
+            self.bs._handle_output_line(
+                "menu: transferring call abc123 to 'sip:target@example.com'")
+        h.assert_called_once()
+
+    def test_transfer_failed_line_fires_hook(self):
+        with patch.object(self.bs, "handle_transfer_failed") as h:
+            self.bs._handle_output_line("menu: transfer failure: 486")
+        h.assert_called_once_with("menu: transfer failure: 486")
+
+    def test_transfer_connect_error_fires_failed_hook(self):
+        with patch.object(self.bs, "handle_transfer_failed") as h:
+            self.bs._handle_output_line(
+                "menu: transfer: connect error: some error")
+        h.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -67,5 +67,24 @@ class TestRenderConfigSndfile(unittest.TestCase):
             render_config(enable_sndfile=True)
 
 
+class TestRenderConfigTlsSrtp(unittest.TestCase):
+    def test_sip_cafile_none_leaves_config_unchanged(self):
+        config = render_config()
+        self.assertNotIn("sip_cafile", config)
+
+    def test_sip_cafile_set(self):
+        config = render_config(sip_cafile="/etc/ssl/ca.pem")
+        self.assertIn("sip_cafile\t\t/etc/ssl/ca.pem", config)
+
+    def test_srtp_disabled_by_default(self):
+        config = render_config()
+        self.assertIn("#module\t\t\tsrtp.so", config)
+
+    def test_srtp_enabled(self):
+        config = render_config(enable_srtp=True)
+        self.assertIn("module\t\t\tsrtp.so", config)
+        self.assertNotIn("#module\t\t\tsrtp.so", config)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_login_retry.py
+++ b/test/test_login_retry.py
@@ -1,0 +1,64 @@
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+import baresipy
+
+
+def make_baresip(**kwargs):
+    kwargs.setdefault("autostart", False)
+    kwargs.setdefault("config_path", tempfile.mkdtemp())
+    with patch.object(baresipy.pexpect, "spawn") as mock_spawn:
+        mock_spawn.return_value = MagicMock()
+        bs = baresipy.BareSIP(**kwargs)
+    return bs
+
+
+class TestLoginRetryDisabledByDefault(unittest.TestCase):
+    def test_default_quits_immediately(self):
+        bs = make_baresip()
+        with patch.object(bs, "handle_login_failure") as hf, \
+                patch("baresipy.threading.Timer") as mock_timer:
+            bs._handle_output_line("ua: SIP register failed: bad creds")
+        hf.assert_called_once()
+        mock_timer.assert_not_called()
+
+
+class TestLoginRetryEnabled(unittest.TestCase):
+    def setUp(self):
+        self.bs = make_baresip(max_login_retries=2, login_retry_delay=1.0)
+
+    def test_failure_schedules_retry_instead_of_quitting(self):
+        with patch.object(self.bs, "handle_login_failure") as hf, \
+                patch.object(self.bs, "handle_login_retry") as hr, \
+                patch("baresipy.threading.Timer") as mock_timer:
+            timer_instance = MagicMock()
+            mock_timer.return_value = timer_instance
+            self.bs._handle_output_line(
+                "ua: SIP register failed: bad creds")
+        hf.assert_not_called()
+        hr.assert_called_once_with(1)
+        mock_timer.assert_called_once_with(1.0, self.bs.login)
+        timer_instance.start.assert_called_once()
+
+    def test_exhausting_retries_eventually_calls_handle_login_failure(self):
+        with patch.object(self.bs, "handle_login_failure") as hf, \
+                patch("baresipy.threading.Timer"):
+            for _ in range(self.bs.max_login_retries):
+                self.bs._handle_output_line(
+                    "ua: SIP register failed: bad creds")
+            hf.assert_not_called()
+            # one more failure exceeds max_login_retries
+            self.bs._handle_output_line(
+                "ua: SIP register failed: bad creds")
+        hf.assert_called_once()
+
+    def test_successful_login_resets_retry_counter(self):
+        self.bs._login_retry_count = 2
+        self.bs._handle_output_line(
+            "All 1 useragent registered successfully!")
+        self.assertEqual(self.bs._login_retry_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_tls_srtp.py
+++ b/test/test_tls_srtp.py
@@ -1,0 +1,54 @@
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+import baresipy
+
+
+def make_baresip(**kwargs):
+    kwargs.setdefault("autostart", False)
+    kwargs.setdefault("config_path", tempfile.mkdtemp())
+    with patch.object(baresipy.pexpect, "spawn") as mock_spawn:
+        mock_spawn.return_value = MagicMock()
+        bs = baresipy.BareSIP(**kwargs)
+    return bs
+
+
+class TestMediaEncryptionAccountLine(unittest.TestCase):
+    def test_media_encryption_appended_to_account_line(self):
+        bs = make_baresip(user="u", pwd="p", gateway="example.com",
+                           media_encryption="srtp-mand")
+        self.assertIn(";mediaenc=srtp-mand", bs._login)
+
+    def test_no_media_encryption_omits_mediaenc(self):
+        bs = make_baresip(user="u", pwd="p", gateway="example.com")
+        self.assertNotIn("mediaenc", bs._login)
+
+    def test_login_sends_account_line_with_mediaenc(self):
+        bs = make_baresip(user="u", pwd="p", gateway="example.com",
+                           media_encryption="dtls_srtp")
+        bs.ready = True
+        with patch.object(bs.baresip, "sendline") as h:
+            bs.login()
+        sent = h.call_args[0][0]
+        self.assertIn(";mediaenc=dtls_srtp", sent)
+
+
+class TestSipCafileConfig(unittest.TestCase):
+    def test_sip_cafile_passed_through_to_rendered_config(self):
+        bs = make_baresip(sip_cafile="/etc/ssl/ca.pem")
+        self.assertIn("sip_cafile\t\t/etc/ssl/ca.pem", bs.config)
+
+    def test_media_encryption_enables_srtp_in_config(self):
+        bs = make_baresip(user="u", pwd="p", gateway="example.com",
+                           media_encryption="srtp")
+        self.assertIn("module\t\t\tsrtp.so", bs.config)
+        self.assertNotIn("#module\t\t\tsrtp.so", bs.config)
+
+    def test_no_media_encryption_srtp_stays_disabled(self):
+        bs = make_baresip()
+        self.assertIn("#module\t\t\tsrtp.so", bs.config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the call-handling primitives that interactive voice applications need.

- **Barge-in / interruptible playback**: `stop_audio()` cuts playback immediately; `send_audio()` waits in interruptible steps (and supports `block=False` with a timer-based revert); `speak()` synthesizes and streams sentence-by-sentence, stopping mid-utterance on interruption or call drop; new `handle_audio_interrupted()` hook. Apps can now run VAD on the rx stream while the bot talks and cut it off when the caller speaks.
- **Call transfer**: `transfer(uri)` sends a REFER via baresip's `/transfer`; `handle_transfer_ok()` / `handle_transfer_failed(reason)` hooks (failure strings matched from baresip's menu/call sources; "ok" fires on initiation — final success manifests as the transferee call establishing).
- **Caller identity + history**: `CallInfo` dataclass (`baresipy/call.py`) with parsed user/host, direction, timestamps, end reason, and accumulated DTMF; `current_call_info` for the active call and `call_history` (last 100). `current_call` string unchanged for compatibility.
- **Registration recovery**: `max_login_retries=` / `login_retry_delay=` — re-registers with a `handle_login_retry(attempt)` hook before giving up; default behavior unchanged.
- **TLS + SRTP**: `sip_cafile=` (server verification for `transport="tls"`) and `media_encryption=` ("srtp", "srtp-mand", "srtp-mandf", "dtls_srtp") appending `;mediaenc=` to the account and loading the srtp module via `render_config(enable_srtp=...)`.

## Verification
125 unit tests green (42 new) in a fresh venv; ruff clean; `uv build` ok; live e2e call test runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
