### PR TITLE
feat: declarative IVR menus and gateway v2 (transfer, barge-in, call history)

### DIFF
--- a/baresipy/ivr.py
+++ b/baresipy/ivr.py
@@ -1,0 +1,233 @@
+"""Declarative IVR (Interactive Voice Response) menus for `BareSIP`.
+
+Build a tree of `IVRNode` menus and run a caller through it with
+`IVRSession`, or use `IVRPhone` for a ready-made auto-answering phone that
+drives one IVR tree per call.
+"""
+import threading
+from dataclasses import dataclass, field
+from time import time as _time
+from typing import Callable, Dict, List, Optional, Union
+
+from baresipy import BareSIP
+from baresipy.utils.log import LOG
+
+IVROption = Union["IVRNode", Callable[["IVRSession"], None], str]
+
+
+@dataclass
+class IVRNode:
+    """A single menu in an IVR tree.
+
+    `options` maps a single DTMF digit/char to one of:
+        - another `IVRNode` (descend into a submenu)
+        - a callable `(session) -> None` (run an action, then repeat this
+          menu unless the callback itself navigates the session away)
+        - `"hangup"` - end the call
+        - `"transfer:<uri>"` - blind-transfer the call to `<uri>`
+        - `"back"` - return to the previous menu
+        - `"repeat"` - re-speak the current prompt
+    """
+    prompt: str
+    options: Dict[str, IVROption] = field(default_factory=dict)
+    timeout: float = 10.0
+    invalid_prompt: str = "Sorry, that is not a valid option."
+    timeout_prompt: str = "Are you still there?"
+    max_retries: int = 2
+    fallback: Optional[str] = None  # "hangup" | "transfer:<uri>" | None -> hangup
+
+
+class IVRSession:
+    """Runs one caller through a menu tree on an active call.
+
+    Digits are delivered via `on_digit(char)`, meant to be called from a
+    `BareSIP.handle_dtmf_received` hook (or `IVRPhone` does this for you).
+    """
+
+    def __init__(self, phone: BareSIP, root: IVRNode):
+        self.phone = phone
+        self.root = root
+        self._stack: List[IVRNode] = []
+        self._path: List[str] = []
+        self._pending_digit: Optional[str] = None
+        self._digit_event = threading.Event()
+        self._stopped = False
+
+    @property
+    def path(self) -> List[str]:
+        return list(self._path)
+
+    def on_digit(self, char: str) -> None:
+        """Feed a DTMF digit into the session. Interrupts any in-flight
+        prompt playback (barge-in)."""
+        if self._stopped:
+            return
+        self._pending_digit = char
+        try:
+            self.phone.stop_audio()
+        except Exception as e:
+            LOG.debug(f"stop_audio during barge-in failed: {e}")
+        self._digit_event.set()
+
+    def stop(self) -> None:
+        self._stopped = True
+        self._digit_event.set()
+
+    def _call_alive(self) -> bool:
+        return bool(getattr(self.phone, "call_established", False))
+
+    def _speak(self, text: str) -> None:
+        if not text:
+            return
+        try:
+            self.phone.speak(text)
+        except Exception as e:
+            LOG.warning(f"IVR speak failed: {e}")
+
+    def _wait_for_digit(self, timeout: float) -> Optional[str]:
+        deadline = _time() + timeout
+        while _time() < deadline:
+            if self._stopped or not self._call_alive():
+                return None
+            if self._pending_digit is not None:
+                digit = self._pending_digit
+                self._pending_digit = None
+                self._digit_event.clear()
+                return digit
+            self._digit_event.wait(min(0.1, max(deadline - _time(), 0)))
+        # one last check in case a digit landed right at the deadline
+        if self._pending_digit is not None:
+            digit = self._pending_digit
+            self._pending_digit = None
+            self._digit_event.clear()
+            return digit
+        return None
+
+    def _resolve(self, node: IVRNode) -> str:
+        """Run a single node until it navigates elsewhere or the
+        call/session ends. Returns one of "push" (a submenu was entered -
+        the submenu is left on top of `self._stack`), "pop" ("back" was
+        selected), or "end" (hangup/transfer/call-end/session-stop)."""
+        retries = 0
+        first = True
+        while True:
+            if self._stopped or not self._call_alive():
+                return "end"
+            if first:
+                self._speak(node.prompt)
+                first = False
+            digit = self._wait_for_digit(node.timeout)
+            if self._stopped or not self._call_alive():
+                return "end"
+            if digit is None:
+                retries += 1
+                if retries > node.max_retries:
+                    self._fallback(node)
+                    return "end"
+                self._speak(node.timeout_prompt)
+                first = True
+                continue
+
+            action = node.options.get(digit)
+            if action is None:
+                retries += 1
+                if retries > node.max_retries:
+                    self._fallback(node)
+                    return "end"
+                self._speak(node.invalid_prompt)
+                first = True
+                continue
+
+            self._path.append(digit)
+            retries = 0
+
+            if action == "repeat":
+                first = True
+                continue
+            if action == "back":
+                return "pop"
+            if action == "hangup":
+                self._hangup()
+                return "end"
+            if isinstance(action, str) and action.startswith("transfer:"):
+                self._transfer(action[len("transfer:"):])
+                return "end"
+            if isinstance(action, IVRNode):
+                self._stack.append(action)
+                return "push"
+            if callable(action):
+                try:
+                    action(self)
+                except Exception as e:
+                    LOG.exception(f"IVR action callback failed: {e}")
+                if self._stopped or not self._call_alive():
+                    return "end"
+                first = True
+                continue
+            LOG.warning(f"IVR: unrecognised option value {action!r}")
+            return "end"
+
+    def _fallback(self, node: IVRNode) -> None:
+        fb = node.fallback or "hangup"
+        if fb.startswith("transfer:"):
+            self._transfer(fb[len("transfer:"):])
+        else:
+            self._hangup()
+
+    def _hangup(self) -> None:
+        try:
+            self.phone.hang()
+        except Exception as e:
+            LOG.debug(f"IVR hangup failed: {e}")
+
+    def _transfer(self, uri: str) -> None:
+        try:
+            self.phone.transfer(uri)
+        except Exception as e:
+            LOG.debug(f"IVR transfer failed: {e}")
+
+    def run(self) -> None:
+        """Blocking loop: navigates the menu tree until the call ends or
+        the session reaches hangup/transfer."""
+        self._stack = [self.root]
+        while not self._stopped and self._call_alive() and self._stack:
+            node = self._stack[-1]
+            outcome = self._resolve(node)
+            if outcome == "end":
+                return
+            if outcome == "pop":
+                self._stack.pop()
+                if not self._stack:
+                    return
+            # "push" leaves the new node on top of self._stack already
+
+
+class IVRPhone(BareSIP):
+    """Convenience `BareSIP` subclass: auto-answers and runs a given
+    `IVRNode` tree per call in a daemon thread."""
+
+    def __init__(self, *args, ivr: Optional[IVRNode] = None, **kwargs):
+        self.ivr_root = ivr
+        self._session: Optional[IVRSession] = None
+        super().__init__(*args, **kwargs)
+
+    def handle_incoming_call(self, number: str) -> None:
+        self.accept_call()
+
+    def handle_call_established(self) -> None:
+        if self.ivr_root is None:
+            LOG.warning("IVRPhone has no ivr root configured")
+            return
+        self._session = IVRSession(self, self.ivr_root)
+        t = threading.Thread(target=self._session.run, daemon=True)
+        t.start()
+
+    def handle_call_ended(self, reason: str, number: Optional[str] = None) -> None:
+        if self._session is not None:
+            self._session.stop()
+            self._session = None
+
+    def handle_dtmf_received(self, char: str, duration: int) -> None:
+        super().handle_dtmf_received(char, duration)
+        if self._session is not None:
+            self._session.on_digit(char)

--- a/baresipy/server.py
+++ b/baresipy/server.py
@@ -9,7 +9,9 @@ import asyncio
 import os
 import tempfile
 import time
+import uuid
 from collections import deque
+from dataclasses import asdict
 from os.path import isfile
 from typing import Any, Deque, Dict, List, Optional
 
@@ -42,13 +44,16 @@ class GatewayPhone(BareSIP):
         self._loop = loop
         self._events: Deque[Dict[str, Any]] = deque(maxlen=_EVENT_BACKLOG)
         self._subscribers: List[asyncio.Queue] = []
+        self._call_id: Optional[str] = None
         super().__init__(*args, **kwargs)
 
     def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
 
     def _emit(self, event: str, data: Optional[dict] = None) -> None:
-        payload = {"event": event, "data": data or {}, "ts": time.time()}
+        data = dict(data or {})
+        data.setdefault("call_id", self._call_id)
+        payload = {"event": event, "data": data, "ts": time.time()}
         self._events.append(payload)
         loop = self._loop
         for q in list(self._subscribers):
@@ -73,19 +78,31 @@ class GatewayPhone(BareSIP):
     def backlog(self) -> List[Dict[str, Any]]:
         return list(self._events)
 
+    def _new_call_id(self) -> str:
+        self._call_id = uuid.uuid4().hex
+        if self.current_call_info is not None:
+            self.current_call_info.call_id = self._call_id
+        return self._call_id
+
     # hooks
     def handle_incoming_call(self, number: str) -> None:
+        self._new_call_id()
         self._emit("incoming_call", {"number": number})
         if self.auto_answer:
             self.accept_call()
+
+    def handle_call_start(self) -> None:
+        self._new_call_id()
 
     def handle_call_established(self) -> None:
         self._emit("call_established", {"number": self.current_call})
 
     def handle_call_ended(self, reason: str, number: Optional[str] = None) -> None:
         self._emit("call_ended", {"reason": reason, "number": number})
+        self._call_id = None
 
     def handle_dtmf_received(self, char: str, duration: int) -> None:
+        super().handle_dtmf_received(char, duration)
         self._emit("dtmf_received", {"char": char, "duration": duration})
 
     def handle_login_success(self) -> None:
@@ -96,6 +113,10 @@ class GatewayPhone(BareSIP):
 
 
 class CallRequest(BaseModel):
+    uri: str
+
+
+class TransferRequest(BaseModel):
     uri: str
 
 
@@ -184,6 +205,31 @@ def create_app(phone: Optional[BareSIP] = None, *,
             raise _no_call()
         await asyncio.to_thread(phone.resume)
         return {"ok": True}
+
+    @app.post("/transfer", dependencies=[Depends(check_auth)])
+    async def post_transfer(req: TransferRequest, phone: BareSIP = Depends(get_phone)):
+        if not phone.current_call:
+            raise _no_call()
+        await asyncio.to_thread(phone.transfer, req.uri)
+        return {"ok": True}
+
+    @app.post("/stop_audio", dependencies=[Depends(check_auth)])
+    async def post_stop_audio(phone: BareSIP = Depends(get_phone)):
+        await asyncio.to_thread(phone.stop_audio)
+        return {"ok": True}
+
+    @app.get("/calls", dependencies=[Depends(check_auth)])
+    async def get_calls(phone: BareSIP = Depends(get_phone)):
+        history = list(getattr(phone, "call_history", []) or [])
+        out = []
+        for info in reversed(history):
+            try:
+                item = asdict(info)
+            except TypeError:
+                item = dict(getattr(info, "__dict__", {}))
+            item.setdefault("call_id", getattr(info, "call_id", None))
+            out.append(item)
+        return out
 
     @app.post("/speak", dependencies=[Depends(check_auth)])
     async def post_speak(req: SpeakRequest, phone: BareSIP = Depends(get_phone)):

--- a/docs/http-gateway.md
+++ b/docs/http-gateway.md
@@ -162,3 +162,35 @@ asyncio.run(consume_audio())
 
 See also [examples/gateway_client.py](../examples/gateway_client.py) for a runnable script that
 places a call over REST and prints `/ws/events` as they arrive.
+
+## Gateway v2 additions
+
+New endpoints added on top of the table above:
+
+| method | path | body | responses |
+|---|---|---|---|
+| POST | `/transfer` | `{"uri": "sip:..."}` | `200 {"ok": true}` · `409` no active call |
+| POST | `/stop_audio` | — | `200 {"ok": true}` |
+| GET | `/calls` | — | `200` list of finished/current call records, newest first |
+
+`/transfer` blind-transfers the active call via `BareSIP.transfer` (SIP REFER, `menu` module).
+
+`/stop_audio` interrupts any in-flight `/speak` or `/audio` playback immediately (barge-in),
+calling `BareSIP.stop_audio`. Safe to call with no active call.
+
+`/calls` returns `phone.call_history` serialized as JSON objects (one per finished call, plus the
+current in-progress call if any), each with `uri`, `user`, `host`, `direction`, `started`, `ended`,
+`reason`, `dtmf`, and `call_id`.
+
+`GatewayPhone` now assigns a `call_id` (a `uuid4` hex string) per call, generated when a call
+starts (incoming or outgoing) and included as `"call_id"` in every `/ws/events` payload's `data`
+for that call, so a client can group events belonging to the same call together.
+
+```bash
+curl -s -X POST http://localhost:8000/transfer -H 'content-type: application/json' \
+    -d '{"uri": "sip:human@example.com"}'
+
+curl -s -X POST http://localhost:8000/stop_audio
+
+curl -s http://localhost:8000/calls
+```

--- a/docs/ivr.md
+++ b/docs/ivr.md
@@ -1,0 +1,94 @@
+# IVR menus (`baresipy.ivr`)
+
+Declarative phone-tree menus on top of `BareSIP`, for building "press 1 for X, 2 for Y" style
+call flows without hand-rolling DTMF state machines.
+
+## Concepts
+
+- `IVRNode` - one menu: a spoken `prompt` plus a mapping of DTMF digit -> option.
+- `IVRSession` - runs one caller through a tree of `IVRNode`s on an active call.
+- `IVRPhone` - a ready-made `BareSIP` subclass that auto-answers and runs one `IVRSession` per
+  call, forwarding DTMF automatically.
+
+## `IVRNode`
+
+```python
+from baresipy.ivr import IVRNode
+
+root = IVRNode(
+    prompt="Press 1 for sales, 2 for support, 0 to hang up.",
+    options={
+        "1": some_submenu,           # another IVRNode
+        "2": "transfer:sip:support@example.com",
+        "9": my_callback,            # callable(session) -> None
+        "0": "hangup",
+    },
+    timeout=10.0,               # seconds to wait for a digit
+    invalid_prompt="Sorry, that is not a valid option.",
+    timeout_prompt="Are you still there?",
+    max_retries=2,               # invalid/timeout retries before fallback
+    fallback=None,                # "hangup" (default) or "transfer:<uri>"
+)
+```
+
+Each entry in `options` is one of:
+
+- an **`IVRNode`** - descend into a submenu; `"back"` in the submenu returns here
+- a **callable** `(session: IVRSession) -> None` - run an action (e.g. speak some text, look
+  something up), then re-speak the current menu's prompt
+- `"hangup"` - end the call
+- `"transfer:<uri>"` - blind-transfer the call to `<uri>` (`BareSIP.transfer`)
+- `"back"` - return to the previous menu (only meaningful inside a submenu)
+- `"repeat"` - just re-speak the current prompt
+
+If the caller presses an unmapped digit, or does not press anything before `timeout` seconds
+elapse, the node's `invalid_prompt`/`timeout_prompt` is spoken and the prompt repeats, up to
+`max_retries` times. After that, `fallback` runs (`"hangup"` by default).
+
+Pressing any digit interrupts (barges in on) whatever is currently playing, via
+`BareSIP.stop_audio()`.
+
+## `IVRSession`
+
+```python
+from baresipy.ivr import IVRSession
+
+session = IVRSession(phone, root)
+session.run()          # blocking; navigates the tree until hangup/transfer/call end
+session.path            # -> ["1", "2"] - digits pressed so far, in order
+session.stop()           # abort a running session from another thread
+```
+
+`IVRSession` only needs digits delivered to it - it does not read them off the wire itself. Feed
+digits in from a `BareSIP.handle_dtmf_received` override:
+
+```python
+class MyPhone(BareSIP):
+    def handle_call_established(self):
+        self.session = IVRSession(self, root)
+        Thread(target=self.session.run, daemon=True).start()
+
+    def handle_dtmf_received(self, char, duration):
+        super().handle_dtmf_received(char, duration)
+        self.session.on_digit(char)
+```
+
+`IVRPhone` (below) does exactly this for you.
+
+## `IVRPhone`
+
+```python
+from baresipy.ivr import IVRNode, IVRPhone
+
+root = IVRNode(prompt="Press 1 for hours, 0 to hang up.", options={
+    "1": lambda session: session.phone.speak("We are open nine to five."),
+    "0": "hangup",
+})
+
+phone = IVRPhone(user, pwd, gateway, ivr=root)
+```
+
+`IVRPhone` auto-accepts every incoming call and runs a fresh `IVRSession` against `ivr` in a
+daemon thread per call, ending the session automatically when the call ends.
+
+See [examples/ivr_menu.py](../examples/ivr_menu.py) for a complete runnable demo.

--- a/examples/ivr_menu.py
+++ b/examples/ivr_menu.py
@@ -1,0 +1,52 @@
+"""Declarative IVR menu demo.
+
+Auto-answers incoming calls and runs a small phone-tree:
+    1 - opening hours
+    2 - a joke
+    3 - transfer to a human
+    0 - hang up
+
+Required installs:
+    pip install baresipy[ovos] pyjokes
+"""
+from time import sleep
+
+from baresipy.ivr import IVRNode, IVRPhone, IVRSession
+
+gateway = "your_sip.gateway.net"
+user = "your_phone"
+pswd = "your_password"
+
+
+def opening_hours(session: IVRSession) -> None:
+    # speaks static text, then the caller lands back on the root prompt
+    session.phone.speak("We are open Monday to Friday, nine to five.")
+
+
+def tell_joke(session: IVRSession) -> None:
+    try:
+        from pyjokes import get_joke  # pip install pyjokes
+        joke = get_joke()
+    except ImportError:
+        joke = "Why did the developer quit? They didn't get arrays."
+    session.phone.speak(joke)
+
+
+root = IVRNode(
+    prompt=(
+        "Press 1 for opening hours, 2 for a joke, "
+        "3 to speak to a human, 0 to end the call."
+    ),
+    options={
+        "1": opening_hours,
+        "2": tell_joke,
+        "3": "transfer:sip:human@example.com",
+        "0": "hangup",
+    },
+    fallback="hangup",
+)
+
+phone = IVRPhone(user, pswd, gateway, ivr=root)
+
+while phone.running:
+    sleep(1)

--- a/test/test_ivr.py
+++ b/test/test_ivr.py
@@ -1,0 +1,184 @@
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from baresipy.ivr import IVRNode, IVRPhone, IVRSession
+
+
+def make_phone(established=True):
+    phone = MagicMock()
+    phone.call_established = established
+    return phone
+
+
+class TestIVRNavigation(unittest.TestCase):
+    def test_digit_navigates_to_submenu(self):
+        sub = IVRNode(prompt="sub menu", options={"9": "hangup"})
+        root = IVRNode(prompt="root menu", options={"1": sub})
+        phone = make_phone()
+        session = IVRSession(phone, root)
+
+        import threading
+        t = threading.Thread(target=session.run, daemon=True)
+        t.start()
+        session.on_digit("1")
+        time.sleep(0.1)
+        session.on_digit("9")
+        t.join(timeout=2)
+        phone.speak.assert_any_call("root menu")
+        phone.speak.assert_any_call("sub menu")
+        phone.hang.assert_called_once()
+
+    def test_action_callback_invoked_and_menu_repeats(self):
+        called = []
+
+        def action(session):
+            called.append(session.path)
+            phone.call_established = False  # end the loop after the action
+
+        root = IVRNode(prompt="root", options={"5": action})
+        phone = make_phone()
+        session = IVRSession(phone, root)
+
+        import threading
+        t = threading.Thread(target=session.run, daemon=True)
+        t.start()
+        session.on_digit("5")
+        t.join(timeout=2)
+        self.assertEqual(called, [["5"]])
+        phone.speak.assert_any_call("root")
+
+    def test_invalid_digit_then_retry_then_valid(self):
+        root = IVRNode(prompt="root", options={"1": "hangup"},
+                        invalid_prompt="bad digit", max_retries=2)
+        phone = make_phone()
+        session = IVRSession(phone, root)
+
+        import threading
+        t = threading.Thread(target=session.run, daemon=True)
+        t.start()
+        session.on_digit("9")  # invalid
+        time.sleep(0.1)
+        session.on_digit("1")  # valid -> hangup
+        t.join(timeout=2)
+        phone.speak.assert_any_call("bad digit")
+        phone.hang.assert_called_once()
+
+    def test_timeout_speaks_timeout_prompt_then_falls_back(self):
+        root = IVRNode(prompt="root", options={}, timeout=0.05,
+                        timeout_prompt="still there?", max_retries=1,
+                        fallback="hangup")
+        phone = make_phone()
+        session = IVRSession(phone, root)
+        session.run()
+        phone.speak.assert_any_call("still there?")
+        phone.hang.assert_called_once()
+
+    def test_max_retries_exceeded_falls_back_to_hangup(self):
+        root = IVRNode(prompt="root", options={}, timeout=0.05,
+                        max_retries=1, fallback="hangup")
+        phone = make_phone()
+        session = IVRSession(phone, root)
+        session.run()
+        phone.hang.assert_called_once()
+
+    def test_max_retries_exceeded_falls_back_to_transfer(self):
+        root = IVRNode(prompt="root", options={}, timeout=0.05,
+                        max_retries=0, fallback="transfer:sip:human@example.com")
+        phone = make_phone()
+        session = IVRSession(phone, root)
+        session.run()
+        phone.transfer.assert_called_once_with("sip:human@example.com")
+
+    def test_transfer_option_calls_phone_transfer(self):
+        root = IVRNode(prompt="root", options={"3": "transfer:sip:human@example.com"})
+        phone = make_phone()
+        session = IVRSession(phone, root)
+
+        import threading
+        t = threading.Thread(target=session.run, daemon=True)
+        t.start()
+        session.on_digit("3")
+        t.join(timeout=2)
+        phone.transfer.assert_called_once_with("sip:human@example.com")
+
+    def test_digit_during_prompt_interrupts_playback(self):
+        root = IVRNode(prompt="root", options={"1": "hangup"})
+        phone = make_phone()
+        session = IVRSession(phone, root)
+
+        import threading
+        t = threading.Thread(target=session.run, daemon=True)
+        t.start()
+        session.on_digit("1")
+        t.join(timeout=2)
+        phone.stop_audio.assert_called()
+
+    def test_call_end_aborts_run(self):
+        root = IVRNode(prompt="root", options={}, timeout=5)
+        phone = make_phone(established=False)
+        session = IVRSession(phone, root)
+        # should return promptly since call_established is False from the start
+        session.run()
+        phone.hang.assert_not_called()
+
+    def test_hangup_option_calls_hang(self):
+        root = IVRNode(prompt="root", options={"0": "hangup"})
+        phone = make_phone()
+        session = IVRSession(phone, root)
+
+        import threading
+        t = threading.Thread(target=session.run, daemon=True)
+        t.start()
+        session.on_digit("0")
+        t.join(timeout=2)
+        phone.hang.assert_called_once()
+
+    def test_path_tracks_digits_pressed(self):
+        sub = IVRNode(prompt="sub", options={"9": "hangup"})
+        root = IVRNode(prompt="root", options={"1": sub})
+        phone = make_phone()
+        session = IVRSession(phone, root)
+
+        import threading
+        t = threading.Thread(target=session.run, daemon=True)
+        t.start()
+        session.on_digit("1")
+        time.sleep(0.1)
+        session.on_digit("9")
+        t.join(timeout=2)
+        self.assertEqual(session.path, ["1", "9"])
+
+
+class TestIVRPhone(unittest.TestCase):
+    def test_ivrphone_starts_session_on_call_established(self):
+        root = IVRNode(prompt="root", options={"0": "hangup"})
+        phone = IVRPhone.__new__(IVRPhone)
+        phone.ivr_root = root
+        phone._session = None
+        phone._call_status = "DISCONNECTED"  # session.run() exits immediately
+
+        phone.handle_call_established()
+        self.assertIsNotNone(phone._session)
+        self.assertIsInstance(phone._session, IVRSession)
+
+    def test_ivrphone_stops_session_on_call_ended(self):
+        root = IVRNode(prompt="root", options={"0": "hangup"})
+        phone = IVRPhone.__new__(IVRPhone)
+        phone.ivr_root = root
+        phone._session = MagicMock()
+
+        phone.handle_call_ended("bye", "sip:x@y")
+        phone._session_stopped = True
+
+    def test_ivrphone_forwards_dtmf_to_session(self):
+        phone = IVRPhone.__new__(IVRPhone)
+        phone.current_call_info = None
+        phone._session = MagicMock()
+
+        phone.handle_dtmf_received("5", 100)
+        phone._session.on_digit.assert_called_once_with("5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 
 import baresipy
+from baresipy.call import CallInfo
 from baresipy.server import GatewayPhone, create_app
 
 
@@ -83,6 +84,37 @@ class TestStatusAndCallControl(unittest.TestCase):
         self.assertEqual(self.client.post("/resume").status_code, 200)
         self.phone.hold.assert_called_once()
         self.phone.resume.assert_called_once()
+
+    def test_transfer_happy(self):
+        self.phone.current_call = "sip:foo@bar"
+        resp = self.client.post("/transfer", json={"uri": "sip:human@example.com"})
+        self.assertEqual(resp.status_code, 200)
+        self.phone.transfer.assert_called_once_with("sip:human@example.com")
+
+    def test_transfer_no_call(self):
+        resp = self.client.post("/transfer", json={"uri": "sip:human@example.com"})
+        self.assertEqual(resp.status_code, 409)
+
+    def test_stop_audio(self):
+        resp = self.client.post("/stop_audio")
+        self.assertEqual(resp.status_code, 200)
+        self.phone.stop_audio.assert_called_once()
+
+    def test_calls_returns_history_newest_first(self):
+        older = CallInfo(uri="sip:a@b", user="a", host="b", direction="in",
+                          started=1.0, ended=2.0, reason="200")
+        newer = CallInfo(uri="sip:c@d", user="c", host="d", direction="out",
+                          started=3.0, ended=4.0, reason="200")
+        newer.call_id = "abc123"
+        self.phone.call_history = [older, newer]
+        resp = self.client.get("/calls")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(len(body), 2)
+        self.assertEqual(body[0]["uri"], "sip:c@d")
+        self.assertEqual(body[0]["call_id"], "abc123")
+        self.assertEqual(body[1]["uri"], "sip:a@b")
+        self.assertIsNone(body[1]["call_id"])
 
 
 class TestSpeakDtmfAudio(unittest.TestCase):
@@ -186,6 +218,22 @@ class TestEventsWebsocket(unittest.TestCase):
         with patch.object(gp, "accept_call") as accept:
             gp.handle_incoming_call("sip:caller@x")
             accept.assert_not_called()
+
+    def test_events_carry_call_id(self):
+        gp = make_gateway_phone(auto_answer=False)
+        gp.handle_incoming_call("sip:caller@x")
+        call_id = gp._call_id
+        self.assertIsNotNone(call_id)
+        gp.handle_call_established()
+        event = gp.backlog[-1]
+        self.assertEqual(event["data"]["call_id"], call_id)
+
+    def test_call_id_cleared_after_call_ended(self):
+        gp = make_gateway_phone(auto_answer=False)
+        gp.handle_incoming_call("sip:caller@x")
+        self.assertIsNotNone(gp._call_id)
+        gp.handle_call_ended("bye", "sip:caller@x")
+        self.assertIsNone(gp._call_id)
 
 
 class FakeRxStream:


### PR DESCRIPTION
Adds a declarative IVR layer and extends the HTTP gateway with transfer, barge-in, and call-history endpoints.

- **`baresipy/ivr.py`**: `IVRNode` (prompt + digit map: submenu | callback | `"hangup"` | `"transfer:<uri>"` | `"back"` | `"repeat"`, with timeout/invalid retries and fallback), `IVRSession` (runs one caller through the tree; a digit during a prompt barge-ins via `stop_audio()`), `IVRPhone` (auto-answer + one session per call). "Press 1 for sales" is now ~15 lines — see `examples/ivr_menu.py` and `docs/ivr.md`.
- **Gateway v2**: `POST /transfer`, `POST /stop_audio` (HTTP barge-in), `GET /calls` (serialized `call_history`), and every `/ws/events` payload now carries a per-call `call_id` so consumers can group events by call.

## Verification
145 tests green (14 IVR + gateway additions) in a fresh venv; ruff clean; `uv build` ok; live e2e call test runs on this PR in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
