### PR TITLE
feat: configurable playback frame rate and channels

### DIFF
--- a/baresipy/__init__.py
+++ b/baresipy/__init__.py
@@ -53,7 +53,9 @@ class BareSIP(Thread):
                  max_login_retries: int = 0,
                  login_retry_delay: float = 15.0,
                  media_encryption: Optional[str] = None,
-                 sip_cafile: Optional[str] = None):
+                 sip_cafile: Optional[str] = None,
+                 audio_frame_rate: int = 48000,
+                 audio_channels: int = 2):
         """
         :param max_login_retries: if > 0, retry registration this many
             times (with `login_retry_delay` seconds between attempts)
@@ -69,6 +71,15 @@ class BareSIP(Thread):
         :param sip_cafile: path to a CA bundle used to verify the SIP
             server certificate. Required for real verification when
             `transport="tls"` is used.
+        :param audio_frame_rate: frame rate (Hz) used when converting
+            audio for playback/transmission via `convert_audio`.
+            Defaults to 48000 (previous hardcoded behaviour). Some
+            backends reject 48kHz aufile playback (#16, #18) and need
+            a different value.
+        :param audio_channels: channel count used when converting audio
+            for playback/transmission via `convert_audio`. Defaults to
+            2 (previous hardcoded behaviour). Some backends reject
+            stereo aufile playback (#16, #18) and need mono (1).
         """
         config_path = config_path or join("~", ".baresipy")
         self.config_path = expanduser(config_path)
@@ -160,6 +171,8 @@ class BareSIP(Thread):
         self.max_login_retries = max_login_retries
         self.login_retry_delay = login_retry_delay
         self._login_retry_count = 0
+        self.audio_frame_rate = audio_frame_rate
+        self.audio_channels = audio_channels
         self.baresip = pexpect.spawn(_find_baresip_binary() + ' -f ' + self.config_path)
         super().__init__()
         if autostart:
@@ -424,7 +437,9 @@ class BareSIP(Thread):
             LOG.error("Can't send audio without an active call!")
             return 0.0
         self._tx_interrupted = False
-        wav_file, duration = self.convert_audio(wav_file)
+        wav_file, duration = self.convert_audio(
+            wav_file, frame_rate=self.audio_frame_rate,
+            channels=self.audio_channels)
         # send audio stream
         LOG.info("transmitting audio")
         self.do_command("/ausrc aufile," + wav_file)
@@ -481,7 +496,9 @@ class BareSIP(Thread):
 
     def play(self, audio_file: str, blocking: bool = True) -> None:
         if not audio_file.endswith(".wav"):
-            audio_file, duration = self.convert_audio(audio_file)
+            audio_file, duration = self.convert_audio(
+                audio_file, frame_rate=self.audio_frame_rate,
+                channels=self.audio_channels)
         self.audio = self._play_wav(audio_file, blocking=blocking)
 
     def stop_playing(self) -> None:

--- a/test/test_audio_format.py
+++ b/test/test_audio_format.py
@@ -1,0 +1,45 @@
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+import baresipy
+
+
+def make_baresip(**kwargs):
+    """Create a BareSIP instance without spawning a real baresip process
+    or starting the event-loop thread, and without touching the real
+    ~/.baresipy config directory."""
+    kwargs.setdefault("autostart", False)
+    kwargs.setdefault("config_path", tempfile.mkdtemp())
+    with patch.object(baresipy.pexpect, "spawn") as mock_spawn:
+        mock_spawn.return_value = MagicMock()
+        bs = baresipy.BareSIP(**kwargs)
+    return bs
+
+
+class TestConfigurableAudioFormat(unittest.TestCase):
+    def test_send_audio_uses_custom_frame_rate_and_channels(self):
+        bs = make_baresip(audio_frame_rate=8000, audio_channels=1)
+        with patch.object(bs, "convert_audio") as conv, \
+                patch.object(type(bs), "call_established",
+                              new=property(lambda self: True)), \
+                patch.object(bs, "do_command"):
+            conv.return_value = ("/tmp/x.wav", 3.0)
+            bs.send_audio("f.wav", block=False)
+        conv.assert_called_once_with(
+            "f.wav", frame_rate=8000, channels=1)
+
+    def test_send_audio_defaults_to_48000_stereo(self):
+        bs = make_baresip()
+        with patch.object(bs, "convert_audio") as conv, \
+                patch.object(type(bs), "call_established",
+                              new=property(lambda self: True)), \
+                patch.object(bs, "do_command"):
+            conv.return_value = ("/tmp/x.wav", 3.0)
+            bs.send_audio("f.wav", block=False)
+        conv.assert_called_once_with(
+            "f.wav", frame_rate=48000, channels=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (Opus 4.8 orchestrating, Sonnet 5 drafting this text) via Claude Code — NOT human-reviewed. Verify before acting.

`convert_audio` has always hardcoded `frame_rate=48000, channels=2`, and both callers (`send_audio` and `play`) used those defaults with no way to change them. A few backends reject 48kHz/stereo aufile playback (see community issues #16 and #18), and until now the only workaround was monkeypatching `convert_audio` from outside the class.

This adds two constructor options, `audio_frame_rate` (default `48000`) and `audio_channels` (default `2`), stored on the instance and passed through to `convert_audio` from both `send_audio` and `play`. The defaults match the previous hardcoded values, so nothing changes for existing users unless they opt in. `convert_audio` itself is untouched — same signature, same defaults, still usable as a standalone static method.

Added `test/test_audio_format.py` with two tests: one confirming custom values are passed through to `convert_audio`, and one confirming the defaults are still 48000/2 when no override is given. Full `test/` suite passes (148 passed, 1 e2e test deselected as usual).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable audio frame rate and channel settings.
  * Audio sending and WAV playback now use the selected audio format.
  * Defaults remain 48 kHz stereo for consistent audio quality.

* **Documentation**
  * Added guidance for configuring audio frame rate and channel count when initializing the audio client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->