### PR TITLE
fix: surface all audio-source failures via overridable hook

### DIFF
--- a/baresipy/__init__.py
+++ b/baresipy/__init__.py
@@ -595,6 +595,20 @@ class BareSIP(Thread):
         if error == "failed to set audio-source (No such device)":
             self.handle_audio_stream_failure()
 
+    def handle_audio_source_error(self, error: str) -> None:
+        """Called whenever baresip reports it could not set an
+        audio-source, eg "(No such device)", "(Function not
+        implemented)", "(No such file or directory)", etc - baresip
+        appends whatever errno text applies. Override this to react to
+        or recover from audio-source failures.
+
+        Note this does not, by itself, hang up the call - the one
+        special case that does (the exact "(No such device)" variant)
+        is handled separately via `handle_error`/
+        `handle_audio_stream_failure`, preserving prior behaviour.
+        """
+        LOG.warning("audio-source failure: " + error)
+
     def handle_unhandled_output(self, output: str) -> None:
         LOG.info("Received unhandled output: '{0}'".format(output))
 
@@ -704,8 +718,14 @@ class BareSIP(Thread):
                     self.handle_call_timestamp(ts)
         elif "failed to set audio-source (" in out:
             # the error reason is interpolated by baresip (errno text),
-            # eg "(No such device)" / "(Function not implemented)"
-            self.handle_error(out[out.index("failed to set audio-source ("):])
+            # eg "(No such device)" / "(Function not implemented)" /
+            # "(No such file or directory)". handle_error preserves the
+            # existing "(No such device)" -> hangup special case;
+            # handle_audio_source_error is the new overridable hook that
+            # every variant reaches, without adding any new hangups.
+            error = out[out.index("failed to set audio-source ("):]
+            self.handle_error(error)
+            self.handle_audio_source_error(error)
         elif "terminated by signal" in out or "ua: stop all" in \
                 out:
             self.running = False

--- a/test/test_audio_source_errors.py
+++ b/test/test_audio_source_errors.py
@@ -1,0 +1,48 @@
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+import baresipy
+
+
+def make_baresip(**kwargs):
+    """Create a BareSIP instance without spawning a real baresip process
+    or starting the event-loop thread, and without touching the real
+    ~/.baresipy config directory."""
+    kwargs.setdefault("autostart", False)
+    kwargs.setdefault("config_path", tempfile.mkdtemp())
+    with patch.object(baresipy.pexpect, "spawn") as mock_spawn:
+        mock_spawn.return_value = MagicMock()
+        bs = baresipy.BareSIP(**kwargs)
+    return bs
+
+
+class TestAudioSourceErrorsSurfaceViaHook(unittest.TestCase):
+    def setUp(self):
+        self.bs = make_baresip()
+
+    def test_unrecognized_errno_reaches_new_hook(self):
+        line = "failed to set audio-source (Function not implemented)"
+        with patch.object(self.bs, "handle_audio_source_error") as h:
+            self.bs._handle_output_line(line)
+        h.assert_called_once_with(
+            "failed to set audio-source (Function not implemented)")
+
+    def test_no_such_device_still_hangs_up(self):
+        line = "failed to set audio-source (No such device)"
+        with patch.object(self.bs, "handle_audio_stream_failure") as h:
+            self.bs._handle_output_line(line)
+        h.assert_called_once()
+
+    def test_no_such_file_reaches_hook_without_hangup(self):
+        line = "failed to set audio-source (No such file or directory)"
+        with patch.object(self.bs, "handle_audio_source_error") as h, \
+                patch.object(self.bs, "handle_audio_stream_failure") as hang:
+            self.bs._handle_output_line(line)
+        h.assert_called_once_with(
+            "failed to set audio-source (No such file or directory)")
+        hang.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (Opus 4.8 orchestrating, Sonnet 5 drafting this text) via Claude Code — NOT human-reviewed. Verify before acting.

`handle_error` only reacts to the exact string `failed to set audio-source (No such device)`, but the dispatcher routes every `failed to set audio-source (...)` line to it. baresip interpolates whatever errno text applies — `(Unknown error -2)`, `(Function not implemented)`, `(No such file or directory)`, and so on — so all of those were logged and then dropped, with no way for an app to react (community issues #9, #16, #17: the call can sit ESTABLISHED with dead audio and no actionable signal).

This adds a new overridable method, `handle_audio_source_error(error)`, called for every `failed to set audio-source (...)` line, alongside the existing `handle_error` call. Its default implementation just logs a warning — it does not hang up the call. The existing `(No such device)` → `handle_audio_stream_failure()` special case inside `handle_error` is untouched, so this doesn't add any new automatic hangups; it only makes every other audio-source failure visible and overridable where before it silently vanished into the log.

Added `test/test_audio_source_errors.py` with three tests: an unrecognized errno reaching the new hook, `(No such device)` still triggering the hangup path as before, and `(No such file or directory)` reaching the hook without triggering a hangup (guards against a regression where the new hook accidentally starts hanging up calls). Full `test/` suite passes (149 passed, 1 e2e test deselected as usual), with no pre-existing test changed or removed.
