### PR TITLE
fix: make sndfile recording config patch whitespace-tolerant and non-silent

### DIFF
--- a/baresipy/config.py
+++ b/baresipy/config.py
@@ -2,6 +2,8 @@ from os.path import isdir
 from typing import Optional
 import re
 
+from baresipy.utils.log import LOG
+
 DEFAULT = """#
 # baresip configuration
 #
@@ -230,13 +232,53 @@ def ensure_sndfile_recording(config: str, snd_path: str) -> str:
     :param config: baresip config file contents
     :param snd_path: directory where call recordings should be written
     """
-    if "#module			sndfile.so" in config:
-        config = config.replace(
-            "#module			sndfile.so", "module			sndfile.so")
-    elif "module			sndfile.so" not in config:
-        config = config.replace(
-            "module			vumeter.so",
-            "module			vumeter.so\nmodule			sndfile.so", 1)
+    # whitespace-tolerant match: some user-provided configs use spaces
+    # instead of tabs between "module" and the module name, so do not
+    # rely on the exact tab-formatted DEFAULT template bytes.
+    sndfile_line = re.compile(
+        r"^([ \t]*)(#[ \t]*)?module([ \t]+)sndfile\.so[ \t]*$",
+        re.MULTILINE)
+    module_line = re.compile(
+        r"^([ \t]*)#?module([ \t]+)\S+\.so[ \t]*$", re.MULTILINE)
+
+    match = sndfile_line.search(config)
+    if match:
+        # module line already present, commented or not - make sure it is
+        # active, preserving the original indentation/spacing style
+        leading, _comment, sep = match.group(1), match.group(2), \
+            match.group(3)
+        config = config[:match.start()] + \
+            leading + "module" + sep + "sndfile.so" + config[match.end():]
+    else:
+        # no sndfile.so line at all - insert one after the last known
+        # "module ..." line so it lands in the modules section
+        last_module = None
+        for m in module_line.finditer(config):
+            last_module = m
+        if last_module is not None:
+            # reuse the same separator style (tabs vs spaces) as the
+            # anchor line so the inserted line matches the surrounding
+            # config's formatting
+            sep = last_module.group(2)
+            config = config[:last_module.end()] + \
+                "\nmodule" + sep + "sndfile.so" + config[last_module.end():]
+        else:
+            # config has no recognizable modules section at all - this is
+            # unexpected for a real baresip config, but still try to make
+            # recording work rather than failing silently
+            config = config.rstrip("\n") + \
+                "\n\n# added by baresipy to enable call recording\n" \
+                "module\t\tsndfile.so\n"
+            LOG.warning(
+                "baresip config has no 'module ...' lines - added a "
+                "standalone sndfile.so module line, but this config may "
+                "be malformed and rx recording might not work")
+
+    final_match = sndfile_line.search(config)
+    if final_match is None or final_match.group(0).lstrip().startswith("#"):
+        LOG.warning(
+            "failed to enable the sndfile.so module in the baresip "
+            "config - call recording (record_rx) will not work")
 
     if "snd_path" in config:
         config = re.sub(r"^snd_path\s+.*$", "snd_path\t\t" + snd_path,

--- a/test/test_sndfile_config.py
+++ b/test/test_sndfile_config.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest.mock import patch
+
+from baresipy.config import DEFAULT, ensure_sndfile_recording, render_config
+
+
+class TestEnsureSndfileRecordingWhitespaceTolerance(unittest.TestCase):
+    def test_spaces_config_without_vumeter_enables_sndfile(self):
+        # a user-supplied (BYO) config using spaces instead of tabs, and
+        # with no vumeter.so line at all - not byte-identical to DEFAULT
+        byo_config = (
+            "# minimal user config\n"
+            "module_path /usr/lib/baresip/modules\n"
+            "\n"
+            "module stdio.so\n"
+            "module opus.so\n"
+            "#module sndfile.so\n"
+            "module alsa.so\n"
+        )
+
+        result = ensure_sndfile_recording(byo_config, "/tmp/rec")
+
+        enabled = False
+        for line in result.splitlines():
+            stripped = line.strip()
+            if stripped == "module sndfile.so" or \
+                    (stripped.startswith("module") and
+                     stripped.endswith("sndfile.so") and
+                     not stripped.startswith("#")):
+                enabled = True
+        self.assertTrue(
+            enabled,
+            "sndfile.so module line should be uncommented/present and "
+            "active even though the config used spaces, not tabs, and "
+            "had no vumeter.so line: %r" % result)
+        self.assertIn("snd_path", result)
+
+    def test_no_modules_section_adds_module_or_warns(self):
+        # a config with no "module ..." lines at all
+        byo_config = (
+            "# a config with no modules section whatsoever\n"
+            "sip_trans_bsize 128\n"
+            "call_max_calls 4\n"
+        )
+
+        sndfile_present = False
+        # baresipy's LOG helper does not propagate to the root logger
+        # (propagate=False), so assertLogs can't observe it directly;
+        # patch LOG.warning to detect the call instead.
+        with patch("baresipy.config.LOG.warning") as mock_warning:
+            result = ensure_sndfile_recording(byo_config, "/tmp/rec")
+            for line in result.splitlines():
+                stripped = line.strip()
+                if "sndfile.so" in stripped and not stripped.startswith("#"):
+                    sndfile_present = True
+
+        warned = mock_warning.called
+        self.assertTrue(
+            sndfile_present or warned,
+            "either sndfile.so should have been added, or a warning "
+            "should have been logged naming the failure")
+
+    def test_default_template_still_enables_sndfile_regression(self):
+        result = ensure_sndfile_recording(DEFAULT, "/tmp/rec")
+        self.assertIn("module\t\t\tsndfile.so", result)
+        self.assertNotIn("#module\t\t\tsndfile.so", result)
+        self.assertIn("snd_path\t\t/tmp/rec", result)
+
+    def test_render_config_default_template_regression(self):
+        config = render_config(enable_sndfile=True, snd_path="/tmp/rec")
+        self.assertIn("module\t\t\tsndfile.so", config)
+        self.assertNotIn("#module\t\t\tsndfile.so", config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (Opus 4.8 orchestrating, Sonnet 5 drafting this text) via Claude Code — NOT human-reviewed. Verify before acting.

`ensure_sndfile_recording` in `baresipy/config.py` enables call recording by patching a baresip config text blob, matching exact tab-formatted strings like `"#module\t\t\tsndfile.so"` and `"module\t\t\tvumeter.so"` from the `DEFAULT` template. But `BareSIP.__init__` loads a pre-existing user config file verbatim when one exists at `config_path/config`. If that config uses different whitespace (spaces instead of tabs), doesn't include a `vumeter.so` line, or was hand-edited in any way, the exact-string match fails and the function silently returns the config unchanged for the module line. `record_rx=True` then produces no recordings and no warning or error anywhere — `get_rx_wav`/`get_rx_stream` just time out and return `None`, which looks like a network or audio fault rather than a config bug.

This PR makes the patch whitespace-tolerant with a regex that matches `module ... sndfile.so` regardless of tabs vs spaces and regardless of whether a `vumeter.so` line is present, inserting the new line after the last recognized `module ...` line (reusing that line's separator style) rather than depending on `vumeter.so` specifically. If no `module` line exists at all, it appends a standalone sndfile module line and logs a warning, since that's not a normal baresip config shape. As a second layer, if the function ever ends up unable to enable the sndfile module, it now logs a clear `LOG.warning` naming that rx recording will not work, instead of failing silently.

Existing tests covering the default template path stay green unchanged. Added `test/test_sndfile_config.py` with: a spaces-formatted config without a vumeter line (previously failed to enable sndfile, now enabled), a config with no modules section at all (either sndfile gets added or a warning is logged, verified via `assertLogs`-equivalent mock on `LOG.warning` since baresipy's custom logger doesn't propagate to the root logger), and a regression check that the default template path still works.

Verified the fix by reverting only `baresipy/config.py` back to the original committed version while keeping the new test file: the spaces-config test fails against the original code (assertion that sndfile.so is enabled fails), then passes again once the fix is restored. Full `test/` suite: 150 passed, 1 deselected, no regressions.
